### PR TITLE
Add check for dropdown to only check if childs are allowed for user

### DIFF
--- a/Kwf/Acl.php
+++ b/Kwf/Acl.php
@@ -278,7 +278,10 @@ class Kwf_Acl extends Zend_Acl
     {
         $menus = array();
         foreach ($resources as $resource) {
-            if ($resource instanceof Kwf_Acl_Resource_Component_Interface) {
+            if ($resource instanceof Kwf_Acl_Resource_MenuDropdown) {
+                // don't validate because visibility of a dropdown should be defined
+                // by it's children
+            } else if ($resource instanceof Kwf_Acl_Resource_Component_Interface) {
                 if (!$this->getComponentAcl()->isAllowed($user, $resource->getComponent())) continue;
             } else if ($resource instanceof Kwf_Acl_Resource_ComponentClass_Interface) {
                 if (!$this->getComponentAcl()->isAllowed($user, $resource->getComponentClass())) continue;


### PR DESCRIPTION
Now the dropdown also shows up when a child is allowed for user but the dropdown itself is not added to his allowed resources.
