### PR TITLE
Responsive form optional

### DIFF
--- a/Kwc/Form/Component.php
+++ b/Kwc/Form/Component.php
@@ -57,6 +57,8 @@ class Kwc_Form_Component extends Kwc_Abstract_Composite_Component
 
         $ret['errorStyle'] = null; //default from config.ini: kwc.form.errorStyle
 
+        $ret['cssClass'] = 'responsive';
+
         return $ret;
     }
 

--- a/Kwc/Form/Component.scss
+++ b/Kwc/Form/Component.scss
@@ -26,11 +26,73 @@
         }
     }
 
-    &.veryNarrow {
-        > div.kwcForm > form {
+    &.responsive {
+
+        &.veryNarrow {
+            > div.kwcForm > form {
+                .kwfFormFieldWrapper {
+                    input, textarea, select {
+                        @include box-sizing(border-box);
+                        width: 100% !important;
+
+                        &.radio {
+                            width: auto !important;
+                        }
+
+                        &[type='checkbox'] {
+                            width: auto !important;
+                        }
+                    }
+                }
+
+                .kwfFieldErrorIconBubble {
+                    background: none transparent;
+                    position: relative;
+                    width: auto;
+
+                    .message {
+                        background: none transparent;
+                        display: block !important;
+                        color: red;
+                        padding: 0;
+                        margin: 0;
+                        right: 0px !important;
+                        white-space: nowrap;
+                        position: relative;
+                    }
+
+                    .arrow {
+                        display: none !important;
+                    }
+                }
+            }
+
+            label {
+                width: 30% !important;
+            }
+
+            .kwfFormFieldRadio {
+                .kwfFormFieldRadio {
+                    label {
+                        width: auto !important;
+                    }
+                }
+            }
+
+            div.kwcFormFieldFile {
+                .underlayFileSelector {
+                    a {
+                        position: absolute;
+                        right: 5px;
+                        top: 4px;
+                    }
+                }
+            }
+        }
+
+        &.veryNarrow.gt350 {
             .kwfFormFieldWrapper {
-                input, textarea, select {
-                    @include box-sizing(border-box);
+                input, textarea, select, {
                     width: 100% !important;
 
                     &.radio {
@@ -43,164 +105,109 @@
                 }
             }
 
+            .kwfFormFieldWrapper.hasLabel {
+                input, textarea, select, {
+                    width: 67% !important;
+
+                    &.radio {
+                        width: auto !important;
+                    }
+
+                    &[type='checkbox'] {
+                        width: auto !important;
+                    }
+                }
+            }
+        }
+
+        &.gt350 {
+            label {
+                float: left;
+                width: 30%;
+                margin-right: 3%;
+            }
+
+            div.kwfFormFieldDateField a.icon {
+                right: 4px;
+                top: 3px;
+            }
+
+            .kwcFormFieldRadio {
+                .kwfFormFieldWrapper {
+                    &.hasLabel {
+                        display: inline-block;
+                    }
+                }
+            }
+
+            .kwfFormFieldMultiCheckbox {
+                .kwfFormFieldMultiCheckbox {
+                    label {
+                        width: auto;
+                        margin-right: 0;
+                    }
+                }
+            }
+
             .kwfFieldErrorIconBubble {
-                background: none transparent;
-                position: relative;
-                width: auto;
-
                 .message {
-                    background: none transparent;
-                    display: block !important;
-                    color: red;
-                    padding: 0;
-                    margin: 0;
-                    right: 0px !important;
-                    white-space: nowrap;
-                    position: relative;
-                }
-
-                .arrow {
-                    display: none !important;
+                    text-align: right;
                 }
             }
         }
 
-        label {
-            width: 30% !important;
-        }
-
-        .kwfFormFieldRadio {
-            .kwfFormFieldRadio {
-                label {
-                    width: auto !important;
-                }
+        &.gt500 {
+            label {
+                width: 120px;
+                margin-right: 20px;
             }
-        }
 
-        div.kwcFormFieldFile {
-            .underlayFileSelector {
-                a {
-                    position: absolute;
-                    right: 5px;
-                    top: 4px;
-                }
-            }
-        }
-    }
-
-    &.veryNarrow.gt350 {
-        .kwfFormFieldWrapper {
-            input, textarea, select, {
-                width: 100% !important;
-
-                &.radio {
-                    width: auto !important;
-                }
-
-                &[type='checkbox'] {
-                    width: auto !important;
-                }
-            }
-        }
-
-        .kwfFormFieldWrapper.hasLabel {
-            input, textarea, select, {
-                width: 67% !important;
-
-                &.radio {
-                    width: auto !important;
-                }
-
-                &[type='checkbox'] {
-                    width: auto !important;
-                }
-            }
-        }
-    }
-
-    &.gt350 {
-        label {
-            float: left;
-            width: 30%;
-            margin-right: 3%;
-        }
-
-        div.kwfFormFieldDateField a.icon {
-            right: 4px;
-            top: 3px;
-        }
-
-        .kwcFormFieldRadio {
             .kwfFormFieldWrapper {
                 &.hasLabel {
                     display: inline-block;
+                    position: relative;
                 }
             }
-        }
 
-        .kwfFormFieldMultiCheckbox {
-            .kwfFormFieldMultiCheckbox {
-                label {
-                    width: auto;
-                    margin-right: 0;
+            .kwfFieldErrorIconBubble {
+                top: 50%;
+                right: 3px;
+                margin-top: -8px;
+
+                .message {
+                    text-align: center;
                 }
             }
-        }
 
-        .kwfFieldErrorIconBubble {
-            .message {
-                text-align: right;
+            div.kwfFormFieldDateField a.icon {
+                right: -20px;
+                top: 50%;
+                margin-top: -8px;
+            }
+
+            .kwcFormFieldRadio {
+                .kwfFieldErrorIconBubble {
+                    right: -3px;
+                }
+            }
+
+            .kwcFormFieldCheckbox {
+                .kwfFieldErrorIconBubble {
+                    right: -10px;
+                    top: 3px;
+                }
+            }
+
+            .kwcFormFieldMultiCheckbox,
+            .kwcFormFieldFile {
+                .kwfFieldErrorIconBubble {
+                    right: -25px;
+                }
             }
         }
     }
 
-    &.gt500 {
-        label {
-            width: 120px;
-            margin-right: 20px;
-        }
-
-        .kwfFormFieldWrapper {
-            &.hasLabel {
-                display: inline-block;
-                position: relative;
-            }
-        }
-
-        .kwfFieldErrorIconBubble {
-            top: 50%;
-            right: 3px;
-            margin-top: -8px;
-
-            .message {
-                text-align: center;
-            }
-        }
-
-        div.kwfFormFieldDateField a.icon {
-            right: -20px;
-            top: 50%;
-            margin-top: -8px;
-        }
-
-        .kwcFormFieldRadio {
-            .kwfFieldErrorIconBubble { 
-                right: -3px;
-            }
-        }
-
-        .kwcFormFieldCheckbox {
-            .kwfFieldErrorIconBubble { 
-                right: -10px;
-                top: 3px;
-            }
-        }
-
-        .kwcFormFieldMultiCheckbox,
-        .kwcFormFieldFile {
-            .kwfFieldErrorIconBubble { 
-                right: -25px;
-            }
-        }
+    &.unResponsive {
+        @extend .responsive.gt500;
     }
 }

--- a/Kwc/FulltextSearch/Search/ViewAjax/SearchForm/Component.php
+++ b/Kwc/FulltextSearch/Search/ViewAjax/SearchForm/Component.php
@@ -8,6 +8,7 @@ class Kwc_FulltextSearch_Search_ViewAjax_SearchForm_Component extends Kwc_Form_C
         $ret['useAjaxRequest'] = false;
         $ret['method'] = 'get';
         $ret['generators']['child']['component']['success'] = false;
+        $ret['cssClass'] = 'unResponsive';
         return $ret;
     }
 }


### PR DESCRIPTION
it makes sense to have a search box not responsive as standard forms.

Using cssClass we can now have predefined styles in kwf where every from can choose from. Default stays to 'responsive' as it currently is.

In the diff I only changed indentation of the scss code, to wrap it into &.responsive - no other styles changed.
