### PR TITLE
LinkTag_Empty does not have a getImageData() function, check if existing

### DIFF
--- a/Kwc/Abstract/Cards/Generator.php
+++ b/Kwc/Abstract/Cards/Generator.php
@@ -90,12 +90,11 @@ class Kwc_Abstract_Cards_Generator extends Kwf_Component_Generator_Static
 
     protected function _formatSelect($parentData, $select = array())
     {
-
         if ($select->hasPart(Kwf_Component_Select::WHERE_COMPONENT_CLASSES)) {
             $cc = $select->getPart(Kwf_Component_Select::WHERE_COMPONENT_CLASSES);
-            if (is_array($parentData)) {
-            } else {
-                $component = $this->_getModel()->fetchColumnByPrimaryId('component', $parentData->dbId);
+            if (count($parentData) == 1) {
+                $pd = $parentData[0];
+                $component = $this->_getModel()->fetchColumnByPrimaryId('component', $pd->dbId);
                 if (!$component || !in_array($this->_settings['component'][$component], $cc)) return null;
             }
         }

--- a/tests/Kwc/Cards/Composite/Component.php
+++ b/tests/Kwc/Cards/Composite/Component.php
@@ -1,0 +1,10 @@
+<?php
+class Kwc_Cards_Composite_Component extends Kwc_Abstract_Composite_Component
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        $ret['generators']['child']['component']['cards'] = 'Kwc_Cards_TestComponent';
+        return $ret;
+    }
+}

--- a/tests/Kwc/Cards/Root.php
+++ b/tests/Kwc/Cards/Root.php
@@ -1,0 +1,17 @@
+<?php
+class Kwc_Cards_Root extends Kwf_Component_NoCategoriesRoot
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        $ret['generators']['cards1'] = array(
+            'component' => 'Kwc_Cards_Composite_Component',
+            'class' => 'Kwf_Component_Generator_Page_Static',
+            'name' => 'Cards1'
+        );
+        unset($ret['generators']['page']);
+        unset($ret['generators']['title']);
+        unset($ret['generators']['box']);
+        return $ret;
+    }
+}

--- a/tests/Kwc/Cards/Sub1/Component.php
+++ b/tests/Kwc/Cards/Sub1/Component.php
@@ -1,0 +1,4 @@
+<?php
+class Kwc_Cards_Sub1_Component extends Kwc_Abstract
+{
+}

--- a/tests/Kwc/Cards/Sub2/Component.php
+++ b/tests/Kwc/Cards/Sub2/Component.php
@@ -1,0 +1,4 @@
+<?php
+class Kwc_Cards_Sub2_Component extends Kwc_Abstract
+{
+}

--- a/tests/Kwc/Cards/Test.php
+++ b/tests/Kwc/Cards/Test.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ */
+class Kwc_Cards_Test extends Kwc_TestAbstract
+{
+    public function setUp()
+    {
+        parent::setUp('Kwc_Cards_Root');
+    }
+
+    public function testLinkTagComponentClass()
+    {
+        $component = Kwf_Component_Data_Root::getInstance()->getComponentById('root_cards1');
+        $c = $component->getChildComponent('-cards')->getChildComponent('-child');
+        $this->assertEquals($c->componentClass, 'Kwc_Cards_Sub2_Component');
+    }
+
+    public function testLinkTagRecursiveChildComponents()
+    {
+        $component = Kwf_Component_Data_Root::getInstance()->getComponentById('root_cards1');
+        $childComponents = $component->getRecursiveChildComponents(
+            array('componentClass' => 'Kwc_Cards_Sub1_Component', 'ignoreVisible'=>true)
+        );
+        $this->assertEquals(0, count($childComponents));
+    }
+}

--- a/tests/Kwc/Cards/TestComponent.php
+++ b/tests/Kwc/Cards/TestComponent.php
@@ -1,0 +1,14 @@
+<?php
+class Kwc_Cards_TestComponent extends Kwc_Abstract_Cards_Component
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        $ret['ownModel'] = 'Kwc_Cards_TestModel';
+        $ret['generators']['child']['component'] = array(
+            'enlarge' => 'Kwc_Cards_Sub1_Component',
+            'none' => 'Kwc_Cards_Sub2_Component',
+        );
+        return $ret;
+    }
+}

--- a/tests/Kwc/Cards/TestModel.php
+++ b/tests/Kwc/Cards/TestModel.php
@@ -1,0 +1,14 @@
+<?php
+class Kwc_Cards_TestModel extends Kwc_TextImage_ImageEnlarge_LinkTag_Model
+{
+    public function __construct($config = array())
+    {
+        $config['proxyModel'] = new Kwf_Model_FnF(array(
+            'primaryKey' => 'component_id',
+            'data'=> array(
+                array('component_id'=>'root_cards1', 'component'=>'none'),
+            )
+        ));
+        parent::__construct($config);
+    }
+}


### PR DESCRIPTION
Somehow Kwc_Basic_LinkTag_Empty_Component was part of childComponents
and therefore the Event tried to get ImageData to delete the cache,
but the function doesn't even exist. So just check if function is
existing.
