### PR TITLE
Update scope-usage for onContentReady to work with new version

### DIFF
--- a/Kwc/Advanced/VideoPlayer/Component.js
+++ b/Kwc/Advanced/VideoPlayer/Component.js
@@ -4,7 +4,7 @@ Kwf.onContentReady(function(el){
             if (el.mediaElement) el.mediaElement.stop();
         }
     }, this);
-}, this);
+});
 Kwf.onElementReady('.kwcAdvancedVideoPlayer', function(el, config) {
     $(el.dom).children('video').mediaelementplayer({
         //custom path to flash

--- a/Kwf_js/EyeCandy/List/Plugins/ActiveChanger/PlayPauseLink.js
+++ b/Kwf_js/EyeCandy/List/Plugins/ActiveChanger/PlayPauseLink.js
@@ -34,7 +34,7 @@ Kwf.EyeCandy.List.Plugins.ActiveChanger.PlayPauseLink = Ext.extend(Kwf.EyeCandy.
                         this._playQueued = true;
                     }
                 }
-            }, this);
+            }, { scope: this });
         }
     },
 

--- a/Kwf_js/EyeCandy/List/Plugins/ActiveListener/LargeContentAjax.js
+++ b/Kwf_js/EyeCandy/List/Plugins/ActiveListener/LargeContentAjax.js
@@ -9,7 +9,7 @@ Kwf.EyeCandy.List.Plugins.ActiveListener.LargeContentAjax = Ext.extend(Kwf.EyeCa
             //recalculate container height as the content height might have changed due to ResponsiveEl
             var h = this._getLargeContentHeight(this.list.getActiveItem());
             this.largeContainer.setHeight(h);
-        }, this);
+        },  { scope: this } );
 
         this.largeContainer = this.list.el.child(this.largeContainerSelector);
         this.largeContent = {};

--- a/Kwf_js/Utils/HistoryState.js
+++ b/Kwf_js/Utils/HistoryState.js
@@ -75,7 +75,7 @@ Kwf.Utils.HistoryStateHash = function() {
         }, this);
         Kwf.onContentReady(function() {
             Kwf.History.init();
-        }, this);
+        });
     }
 };
 Ext.extend(Kwf.Utils.HistoryStateHash, Kwf.Utils.HistoryStateAbstract, {


### PR DESCRIPTION
Scope is now part of options. If options are also set there is no
need to put scope into options because of compatibility fix.
