### PR TITLE
Set lightbox height:100% only if adaptHeight is set

### DIFF
--- a/Kwf/Component/Abstract/ContentSender/Lightbox.php
+++ b/Kwf/Component/Abstract/ContentSender/Lightbox.php
@@ -67,6 +67,7 @@ class Kwf_Component_Abstract_ContentSender_Lightbox extends Kwf_Component_Abstra
             $class = 'kwfLightbox';
             if (isset($options['style'])) $class .= " kwfLightbox$options[style]";
             if (isset($options['cssClass'])) $class .= " $options[cssClass]";
+            if (isset($options['adaptHeight']) && $options['adaptHeight']) $class .= " adaptHeight";
             $options = htmlspecialchars(json_encode($options));
             $lightboxContent = "<div class=\"$class\">\n".
                 "<div class=\"kwfLightboxInner\" style=\"$style\">\n".

--- a/Kwf_js/EyeCandy/Lightbox/Lightbox.css
+++ b/Kwf_js/EyeCandy/Lightbox/Lightbox.css
@@ -2,8 +2,10 @@
     position: absolute;
     z-index: 100;
     top: 0; left: 0;
-    height: 100%;
     width: 100%;
+}
+.kwfLightbox.adaptHeight {
+    height: 100%;
 }
 .kwfLightbox .kwfLightboxInner {
     min-width: 100px;

--- a/Kwf_js/EyeCandy/Lightbox/Lightbox.js
+++ b/Kwf_js/EyeCandy/Lightbox/Lightbox.js
@@ -143,6 +143,9 @@ Kwf.EyeCandy.Lightbox.Lightbox.prototype = {
         if (this.options.height) {
             el.setHeight(parseInt(this.options.height) + el.getBorderWidth("tb") + el.getPadding("tb"));
         }
+        if (this.options.adaptHeight) {
+            this.lightboxEl.addClass('adaptHeight');
+        }
         this.style.afterCreateLightboxEl();
         this.lightboxEl.hide();
     },


### PR DESCRIPTION
In getMaxContentSize lightbox sets overflow:hidden before calculating
and therefore it calculated a wrong height because of height:100%. The site
also lost its scroll-position.
