### PR TITLE
added the order setting for resources

### DIFF
--- a/Kwf/Acl.php
+++ b/Kwf/Acl.php
@@ -393,7 +393,25 @@ class Kwf_Acl extends Zend_Acl
             }
             $menus[] = $menu;
         }
-        return $menus;
+        return $this->_orderResources($menus);
+    }
+
+    private function _orderResources($resources)
+    {
+        usort($resources, array(get_class($this), '_compareMenuConfigOrder'));
+        return $resources;
+    }
+    public static function _compareMenuConfigOrder($first, $second)
+    {
+        $orderFirst = 0;
+        $orderSecond = 0;
+        if (isset($first['menuConfig']['order'])) {
+            $orderFirst = $first['menuConfig']['order'];
+        }
+        if (isset($second['menuConfig']['order'])) {
+            $orderSecond = $second['menuConfig']['order'];
+        }
+        return $orderFirst - $orderSecond;
     }
 
     public function getComponentAcl()

--- a/tests/Kwf/Acl/ResourceOrderTest.php
+++ b/tests/Kwf/Acl/ResourceOrderTest.php
@@ -1,0 +1,86 @@
+<?php
+class Kwf_Acl_ResourceOrderTest extends Kwf_Test_TestCase
+{
+    public function testOrder()
+    {
+        $acl = new Kwf_Acl();
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('foo',
+                array('text'=> 'Foo', 'icon'=>'heart.png'),
+                '/admin/foo'));
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('bar',
+                array('text'=> 'Bar', 'icon'=>'heart.png', 'order'=>1),
+                '/admin/bar'));
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('foo2',
+                array('text'=> 'Foo2', 'icon'=>'heart.png', 'order'=>-1),
+                '/admin/foo2'));
+        $acl->allow(null, 'foo');
+        $acl->allow(null, 'bar');
+        $acl->allow(null, 'foo2');
+        $config = $acl->getMenuConfig(null);
+        $this->assertEquals('Foo2', $config[0]['menuConfig']['text']);
+    }
+
+    public function testOrderDropdown()
+    {
+        $acl = new Kwf_Acl();
+        $acl->add(new Kwf_Acl_Resource_MenuDropdown('fooBar',
+            array('text'=>trl('FooBar'), 'icon'=>'heart.png')));
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('foo',
+                array('text'=> 'Foo', 'icon'=>'heart.png', 'order'=>1),
+                '/admin/foo'), 'fooBar');
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('bar',
+                array('text'=> 'Bar', 'icon'=>'heart.png'),
+                '/admin/bar'), 'fooBar');
+        $acl->allow(null, 'fooBar');
+        $config = $acl->getMenuConfig(null);
+        $this->assertEquals('Bar', $config[0]['children'][0]['menuConfig']['text']);
+    }
+
+    public function testComplexMenu()
+    {
+        $acl = new Kwf_Acl();
+        $acl->add(new Kwf_Acl_Resource_MenuDropdown('fooBar1',
+            array('text'=>'FooBar1', 'icon'=>'heart.png')));
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('foo1',
+                array('text'=> 'Foo1', 'icon'=>'heart.png', 'order' => -1),
+                '/admin/foo'), 'fooBar1');
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('bar1',
+                array('text'=> 'Bar1', 'icon'=>'heart.png', 'order' => -2),
+                '/admin/bar'), 'fooBar1');
+        $acl->allow(null, 'fooBar1');
+        
+        $acl->add(new Kwf_Acl_Resource_MenuDropdown('fooBar2',
+            array('text'=>'FooBar2', 'icon'=>'heart.png', 'order' => 1)));
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('foo2',
+                array('text'=> 'Foo2', 'icon'=>'heart.png', 'order'=>1),
+                '/admin/foo'), 'fooBar2');
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('bar2',
+                array('text'=> 'Bar2', 'icon'=>'heart.png'),
+                '/admin/bar'), 'fooBar2');
+        $acl->allow(null, 'fooBar2');
+
+        $acl->add(new Kwf_Acl_Resource_MenuDropdown('fooBar3',
+            array('text'=>'FooBar3', 'icon'=>'heart.png', 'order' => -1)));
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('foo3',
+                array('text'=> 'Foo3', 'icon'=>'heart.png'),
+                '/admin/foo'), 'fooBar3');
+        $acl->add(new Kwf_Acl_Resource_MenuUrl('bar3',
+                array('text'=> 'Bar3', 'icon'=>'heart.png', 'order'=>-1),
+                '/admin/bar'), 'fooBar3');
+        $acl->allow(null, 'fooBar3');
+        $config = $acl->getMenuConfig(null);
+
+        //order of the dropdowns
+        $this->assertEquals('FooBar3', $config[0]['menuConfig']['text']);
+        $this->assertEquals('FooBar1', $config[1]['menuConfig']['text']);
+
+        //order of fooBar1 children
+        $this->assertEquals('Bar1', $config[1]['children'][0]['menuConfig']['text']);
+
+        //order of fooBar2 children
+        $this->assertEquals('Bar2', $config[2]['children'][0]['menuConfig']['text']);
+
+        //order of fooBar3 children
+        $this->assertEquals('Bar3', $config[0]['children'][0]['menuConfig']['text']);
+    }
+}


### PR DESCRIPTION
default order is 0
positive and negative orders are allowed
order is not affected by priority

example:
$acl->add(new Kwf_Acl_Resource_MenuUrl('bar',
                array('text'=> 'Bar', 'icon'=>'heart.png', 'order'=>1),
                '/admin/bar'));
