### PR TITLE
Fix problem with synctree drag to root

### DIFF
--- a/Kwf/Controller/Action/Auto/Synctree.php
+++ b/Kwf/Controller/Action/Auto/Synctree.php
@@ -513,7 +513,8 @@ abstract class Kwf_Controller_Action_Auto_Synctree extends Kwf_Controller_Action
         if (!$this->_hasPermissions($row, 'move')) {
             throw new Kwf_Exception("Moving this node is not allowed.");
         }
-        $targetRow = $this->_model->getRow($target);
+        $targetRow = null;
+        if ($target && $target != '0') $targetRow = $this->_model->getRow($target);
         if (!$this->_hasPermissions($targetRow, 'moveTo')) {
             throw new Kwf_Exception("Moving here is not allowed.");
         }


### PR DESCRIPTION
If an item is dragged to root $target=0 and model->getRow($target)
throws error. So this checks for this value.
