### PR TITLE
Trigger "menuToggle" event fix if menu is not ready at the time of click...

### DIFF
--- a/Kwc/Menu/Mobile/Component.js
+++ b/Kwc/Menu/Mobile/Component.js
@@ -75,7 +75,10 @@ Kwf.onJElementReady('.kwcMenuMobile', function mobileMenu(el, config) {
 
                 el.find('.slider').replaceWith(Mustache.render(tpl, data, partials));
                 menu = el.find('ul.menu');
-                if (showMenuAfterLoad) menu.slideDown(slideDuration);
+                if (showMenuAfterLoad) {
+                    menu.slideDown(slideDuration);
+                    el.trigger('menuToggle',[slideDuration]);
+                }
 
                 menu.find('li.hasChildren ul.subMenu').prepend('<li class="back">\n' +
                     '<a href="#">\n' +


### PR DESCRIPTION
...ing

If a user tabs or clicks to early on the mobile-menubutton before the menu finished loading,
the mobilemenu will still be displayed after it is loaded via ajax. In this case,
the trigger for the "menuToggle" event was missing.
