### PR TITLE
Create img tag via JS

### DIFF
--- a/Kwc/Abstract/Image/Component.tpl
+++ b/Kwc/Abstract/Image/Component.tpl
@@ -7,7 +7,6 @@
             data-min-width="<?=$this->minWidth;?>"
             data-max-width="<?=$this->maxWidth;?>"
             data-src="<?=$this->baseUrl;?>">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
             <noscript>
                 <?=$this->image($this->image, $this->altText, $this->imgCssClass)?>
             </noscript>

--- a/Kwc/Basic/ImageEnlarge/Component.tpl
+++ b/Kwc/Basic/ImageEnlarge/Component.tpl
@@ -5,7 +5,6 @@
             data-min-width="<?=$this->minWidth;?>"
             data-max-width="<?=$this->maxWidth;?>"
             data-src="<?=$this->baseUrl;?>">
-        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
         <noscript>
             <?=$this->image($this->image, $this->altText, $this->imgCssClass)?>
         </noscript>

--- a/Kwc/Basic/ImageEnlarge/EnlargeTag/ImagePage/Component.tpl
+++ b/Kwc/Basic/ImageEnlarge/EnlargeTag/ImagePage/Component.tpl
@@ -22,7 +22,6 @@
                     data-min-width="<?=$this->minWidth;?>"
                     data-max-width="<?=$this->maxWidth;?>"
                     data-src="<?=$this->baseUrl;?>">
-                <img />
                 <noscript>
                     <img class="centerImage hideWhileLoading" src="<?=$this->imageUrl?>" width="<?=$this->width?>" height="<?=$this->height?>" alt="" />
                 </noscript>

--- a/Kwf_js/Utils/ResponsiveImg.js
+++ b/Kwf_js/Utils/ResponsiveImg.js
@@ -83,11 +83,13 @@ function initResponsiveImgEl(el) {
     var sizePath = baseUrl.replace(DONT_HASH_TYPE_PREFIX+'{width}',
             DONT_HASH_TYPE_PREFIX+width);
 
-    var img = el.child('img', true);
-    Ext.fly(img).on('load', function() {
+    var img = el.createChild({
+        tag: 'img'
+    });
+    img.on('load', function() {
         el.removeClass('webResponsiveImgLoading');
     }, this);
-    img.src = sizePath;
+    img.dom.src = sizePath;
 };
 
 function checkResponsiveImgEl(responsiveImgEl) {

--- a/tests/Kwc/Composite/Images/Test.php
+++ b/tests/Kwc/Composite/Images/Test.php
@@ -21,7 +21,7 @@ class Kwc_Composite_Images_Test extends Kwc_TestAbstract
         $xml = simplexml_import_dom($doc);
 
         $img = $xml->xpath("//img");
-        $this->assertEquals(6, count($img));
+        $this->assertEquals(3, count($img));
         $this->assertEquals(100, (string)$img[1]['width']);
         $this->assertEquals(100, (string)$img[1]['height']);
         $src = (string)$img[1]['src'];


### PR DESCRIPTION
If there exists an image-tag without src it's shown as broken image. This should
not happen.
