### PR TITLE
password hashing with bcrypt

### DIFF
--- a/Kwf/User/Auth/AutoLoginFields.php
+++ b/Kwf/User/Auth/AutoLoginFields.php
@@ -26,7 +26,10 @@ class Kwf_User_Auth_AutoLoginFields extends Kwf_User_Auth_Abstract implements Kw
 
     private function _encodeToken(Kwf_Model_Row_Interface $row, $token)
     {
-        return md5($token.$row->password_salt);
+        $rounds = '08';
+        $string = $this->_getHashHmacStringForBCrypt($row, $token);
+        $salt = substr ( str_shuffle ( './0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' ) , 0, 22 );
+        return crypt ( $string, '$2a$' . $rounds . '$' . $salt );
     }
 
     public function validateAutoLoginToken(Kwf_Model_Row_Interface $row, $token)
@@ -36,10 +39,21 @@ class Kwf_User_Auth_AutoLoginFields extends Kwf_User_Auth_Abstract implements Kw
         $expire = $autologin[0];
         $rowToken = $autologin[1];
         if ($expire < time()) return false;
-        if ($this->_encodeToken($row, $token) == $rowToken) {
+        if ($this->_validateTokenBcrypt($row, $token) == $rowToken) {
             return true;
         }
-
         return false;
+    }
+
+    private function _validateTokenBcrypt($row, $token)
+    {
+        $loginToken = explode(':', $row->autologin);
+        $string = $this->_gethashHmacStringForBCrypt($row, $token);
+        return crypt($string, substr($loginToken[1], 0, 30));
+    }
+    private function _getHashHmacStringForBCrypt(Kwf_Model_Row_Interface $row, $password)
+    {
+        $globalSalt = Kwf_Registry::get('config')->user->passwordSalt;
+        return hash_hmac ( "whirlpool", str_pad ( $password, strlen ( $password ) * 4, sha1 ( $row->id ), STR_PAD_BOTH ), $globalSalt, true );
     }
 }

--- a/Kwf/User/Auth/PasswordFields.php
+++ b/Kwf/User/Auth/PasswordFields.php
@@ -2,6 +2,7 @@
 class Kwf_User_Auth_PasswordFields extends Kwf_User_Auth_Abstract implements Kwf_User_Auth_Interface_Password
 {
     private $_mailTransport = null;
+    private $_passwordHashMethod = 'bcrypt';
 
     public function getRowByIdentity($identity)
     {
@@ -10,9 +11,16 @@ class Kwf_User_Auth_PasswordFields extends Kwf_User_Auth_Abstract implements Kwf
         return $this->_model->getRow($s);
     }
 
-    private function _encodePassword(Kwf_Model_Row_Interface $row, $password)
+    private function _encodePasswordMd5(Kwf_Model_Row_Interface $row, $password)
     {
         return md5($password.$row->password_salt);
+    }
+    private function _encodePasswordBcrypt(Kwf_Model_Row_Interface $row, $password)
+    {
+        $rounds = '08';
+        $string = $this->_getHashHmacStringForBCrypt($row, $password);
+        $salt = substr ( str_shuffle ( './0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' ) , 0, 22 );
+        return crypt ( $string, '$2a$' . $rounds . '$' . $salt );
     }
 
     //not part of interface but used by Kwf_User_EditRow
@@ -24,16 +32,28 @@ class Kwf_User_Auth_PasswordFields extends Kwf_User_Auth_Abstract implements Kwf
 
     public function validatePassword(Kwf_Model_Row_Interface $row, $password)
     {
-        if ($this->_encodePassword($row, $password) == $row->password) {
-            return true;
+        if (preg_match('#^\$2a\$#', $row->password)) {
+            if ($this->_validatePasswordBcrypt($row, $password) == $row->password) {
+                return true;
+            }
+        } else {
+            if ($this->_encodePasswordMd5($row, $password) == $row->password) {
+                return true;
+            }
         }
         return false;
     }
 
     public function setPassword(Kwf_Model_Row_Interface $row, $password)
     {
-        $this->generatePasswordSalt($row);
-        $row->password = $this->_encodePassword($row, $password);
+        if ($this->getPasswordHashMethod() == 'bcrypt') {
+            $row->password = $this->_encodePasswordBcrypt($row, $password);
+        } else if ($this->getPasswordHashMethod() == 'md5') {
+            $this->generatePasswordSalt($row);
+            $row->password = $this->_encodePasswordMd5($row, $password);
+        } else {
+            throw new Kwf_Exception_NotYetImplemented('hashing type not yet implemented');
+        }
         return true;
     }
 
@@ -44,10 +64,9 @@ class Kwf_User_Auth_PasswordFields extends Kwf_User_Auth_Abstract implements Kwf
         $expire = $activateToken[0];
         $rowToken = $activateToken[1];
         if ($expire < time()) return false;
-        if ($this->_encodePassword($row, $token) == $rowToken) {
+        if ($this->_validateActivateTokenBcrypt($row, $token) == $rowToken) {
             return true;
         }
-
         return false;
     }
 
@@ -55,7 +74,7 @@ class Kwf_User_Auth_PasswordFields extends Kwf_User_Auth_Abstract implements Kwf
     {
         $token = substr(Kwf_Util_Hash::hash(microtime(true).uniqid('', true).mt_rand()), 0, 10);
         $expire = time()+24*60*60;
-        $row->activate_token = $expire.':'.$this->_encodePassword($row, $token);
+        $row->activate_token = $expire.':'.$this->_encodePasswordBcrypt($row, $token);
         $row->save();
         return $token;
     }
@@ -76,5 +95,34 @@ class Kwf_User_Auth_PasswordFields extends Kwf_User_Auth_Abstract implements Kwf
             ));
         }
         return true;
+    }
+
+    public function setPasswordHashMethod($method)
+    {
+        $this->_passwordHashMethod = $method;
+    }
+
+    public function getPasswordHashMethod()
+    {
+        return $this->_passwordHashMethod;
+    }
+
+
+    private function _getHashHmacStringForBCrypt(Kwf_Model_Row_Interface $row, $password)
+    {
+        $globalSalt = Kwf_Registry::get('config')->user->passwordSalt;
+        return hash_hmac ( "whirlpool", str_pad ( $password, strlen ( $password ) * 4, sha1 ( $row->id ), STR_PAD_BOTH ), $globalSalt, true );
+    }
+
+    private function _validatePasswordBcrypt($row, $password)
+    {
+        $string = $this->_gethashHmacStringForBCrypt($row, $password);
+        return crypt($string, substr($row->password, 0, 30));
+    }
+    private function _validateActivateTokenBcrypt($row, $token)
+    {
+        $activateToken = explode(':', $row->activate_token);
+        $string = $this->_gethashHmacStringForBCrypt($row, $token);
+        return crypt($string, substr($activateToken[1], 0, 30));
     }
 }

--- a/config.ini
+++ b/config.ini
@@ -94,6 +94,7 @@ user.kwfUserController.model = Kwf_User_EditModel
 user.form.self = Kwf_User_Form
 user.form.grid = Kwf_User_Form
 user.passwordValidator = Kwf_Validate_Password3of4
+user.passwordSalt =
 spamChecker =
 ; hashPrivatePart = ; optional, required if multiple webservers
 ; apcUtilsPass = ; optional, required if multiple webservers

--- a/tests/Kwf/User/AuthAutoLogin/FnF.php
+++ b/tests/Kwf/User/AuthAutoLogin/FnF.php
@@ -7,7 +7,7 @@ class Kwf_User_AuthAutoLogin_FnF extends Kwf_Model_FnF
     protected function _init()
     {
         $this->_data = array(
-            array('id'=>1, 'email' => 'test@vivid.com', 'autologin' => (time()+60*60).':'.md5('footokenxxx'.'123'), 'password_salt' => '123', 'deleted'=>false),
+            array('id'=>1, 'email' => 'test@vivid.com', 'autologin' => null, 'password_salt' => '123', 'deleted'=>false),
             array('id'=>2, 'email' => 'testdel@vivid.com', 'autologin' => null, 'password_salt' => '1234', 'deleted'=>true),
         );
         parent::_init();

--- a/tests/Kwf/User/AuthAutoLogin/Test.php
+++ b/tests/Kwf/User/AuthAutoLogin/Test.php
@@ -5,6 +5,9 @@ class Kwf_User_AuthAutoLogin_Test extends Kwf_Test_TestCase
     {
         parent::setUp();
         $this->_m = Kwf_Model_Abstract::getInstance('Kwf_User_AuthAutoLogin_FnF');
+        $row = $this->_m->getRow(1);
+        $row->autologin = 'AAA';
+        $row->save();
     }
 
     public function testGetAuth()
@@ -40,7 +43,7 @@ class Kwf_User_AuthAutoLogin_Test extends Kwf_Test_TestCase
         $authMethods = $this->_m->getAuthMethods();
         $auth = $authMethods['autoLogin'];
         $row = $this->_m->getRow(1);
-        $validToken = 'footokenxxx';
+        $validToken = $auth->generateAutoLoginToken($row);
         $this->assertTrue($auth->validateAutoLoginToken($row, $validToken));
         $this->assertFalse($auth->validateAutoLoginToken($row, 'bar'));
     }
@@ -52,7 +55,7 @@ class Kwf_User_AuthAutoLogin_Test extends Kwf_Test_TestCase
         $row = $this->_m->getRow(1);
 
         $oldAutologin = $row->autologin;
-        $oldToken = 'footokenxxx';
+        $oldToken = $auth->generateAutoLoginToken($row);
         $this->assertTrue($auth->validateAutoLoginToken($row, $oldToken));
 
         $token = $auth->generateAutoLoginToken($row);

--- a/tests/Kwf/User/AuthPassword/Test.php
+++ b/tests/Kwf/User/AuthPassword/Test.php
@@ -45,7 +45,7 @@ class Kwf_User_AuthPassword_Test extends Kwf_Test_TestCase
         $this->assertFalse($auth->validatePassword($row, 'bar'));
     }
 
-    public function testSetPassword()
+    public function testSetPasswordMd5()
     {
         $authMethods = $this->_m->getAuthMethods();
         $auth = $authMethods['password'];
@@ -53,13 +53,31 @@ class Kwf_User_AuthPassword_Test extends Kwf_Test_TestCase
 
         $oldPasswod = $row->password;
         $oldSalt = $row->password_salt;
-
+        $auth->setPasswordHashMethod('md5');
         $auth->setPassword($row, 'blubb');
+        $this->assertTrue(!preg_match('#^\$2a\$#', $row->password));
         $this->assertFalse($auth->validatePassword($row, 'foo'));
         $this->assertTrue($auth->validatePassword($row, 'blubb'));
 
         $this->assertTrue($oldPasswod != $row->password);
         $this->assertTrue($oldSalt != $row->password_salt);
+    }
+    
+    public function testSetPasswordBcrypt()
+    {
+        $authMethods = $this->_m->getAuthMethods();
+        $auth = $authMethods['password'];
+        $row = $this->_m->getRow(1);
+        $oldPasswod = $row->password;
+        $oldSalt = $row->password_salt;
+        $auth->setPassword($row, 'blubb');
+        $this->assertTrue(!!preg_match('#^\$2a\$#', $row->password));
+        $this->assertFalse($auth->validatePassword($row, 'foo'));
+        $this->assertTrue($auth->validatePassword($row, 'blubb'));
+
+        $this->assertTrue($oldPasswod != $row->password);
+        //the bcrypt doesn't touch the password_salt
+        $this->assertTrue($oldSalt == $row->password_salt);
     }
 
     public function testSendLostPasswordMail()


### PR DESCRIPTION
2 types of passwords are supported at the same time
    bcrypt
    md5
this is, because in case of an update the old passwords are still valid

the password encryption method can be set to md5 (defaults to bcrypt)
