### PR TITLE
Javascripterror in function "doesElementScroll()" in combination with owl-carousel

### DIFF
--- a/Kwf_js/Utils/ResponsiveImg.js
+++ b/Kwf_js/Utils/ResponsiveImg.js
@@ -115,6 +115,10 @@ function doesElementScroll(el) {
         if (overflow == 'auto' || overflow == 'scroll') {
             return true;
         }
+
+        if(!i.parentNode) {
+            return false; 
+        }
         i = i.parentNode;
     }
     return false;


### PR DESCRIPTION
In some cases (probably when owl option changes dynamically and refreshes) owl deletes
some items while a "while loop" is running in "doesElementScroll()" who uses one of that items.
Then the element in the while-loop becomes null while "doesElementScroll" trys to get the parentNode
from that deleted element and then we get an error.
