### PR TITLE
Add second file watcher backend to clear-cache-watcher: watchmedo

### DIFF
--- a/Kwf/Util/Proc.php
+++ b/Kwf/Util/Proc.php
@@ -6,6 +6,7 @@ class Kwf_Util_Proc
 {
     private $_process;
     private $_pipes;
+    private $_terminateOnDestruct = false;
 
     public function __construct($cmd, $descriptorspec, $cwd = null, $env = null)
     {
@@ -15,9 +16,16 @@ class Kwf_Util_Proc
         }
     }
 
+    public function setTerminateOnDestruct($v)
+    {
+        $this->_terminateOnDestruct = (bool)$v;
+    }
+
     public function __destruct()
     {
-//         $this->terminate();
+        if ($this->_terminateOnDestruct && $this->isRunning()) {
+            $this->terminate();
+        }
     }
 
     public function pipe($nr)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "koala-framework/kwf-modernizr": "3.8.x-dev",
         "koala-framework/composer-extra-assets": "1.0.x-dev",
         "twig/twig": "1.16.1",
-        "koala-framework/sourcemaps": "0.1.x-dev"
+        "koala-framework/sourcemaps": "0.1.x-dev",
+        "symfony/process": "2.7.*"
     },
     "extra": {
         "require-bower": {


### PR DESCRIPTION
Uses python watchdog (http://pythonhosted.org/watchdog/)

Watchdog supports Linux, OS X and Windows using their native file watching api.

Unfortunately there is no such library for nodejs which would be easier to install (as we require npm already).
But this is a completely optional dependency for development only...

Also add new dependency: Symfony Process to start the watcher process
This doesn't work with Php 5.2 but we need it for development only