### PR TITLE
IE8 fix when isVisible() is called on an Element that has no tagname

### DIFF
--- a/Kwf_js/Utils/Element.js
+++ b/Kwf_js/Utils/Element.js
@@ -37,7 +37,7 @@ Kwf.Utils.Element.isVisible = function elementIsVisible(el) {
 
     /* variant 3: manuallycheck visiblity+display, basically what ext2 does */
     var ret = true;
-    while (el && el.tagName.toLowerCase() != "body") {
+    while (el && el.tagName && el.tagName.toLowerCase() != "body") {
         var vis = !($(el).css('visibility') == 'hidden' || $(el).css('display') == 'none');
         if (!vis) {
             ret = false;


### PR DESCRIPTION
When using "CallOnContentReady", the function "kwf.Util.ResponsiveImg" in ResponsiveImg.js will be used.
This function then calls "isVisible()" on an Element. In that function, the tagname of the element will be
used, but in some case "el.tagName" doesnt return an string and IE8 shows an error.