### PR TITLE
Add new place to look for js file

### DIFF
--- a/Kwf/Assets/Provider/BowerBuiltFile.php
+++ b/Kwf/Assets/Provider/BowerBuiltFile.php
@@ -31,7 +31,13 @@ class Kwf_Assets_Provider_BowerBuiltFile extends Kwf_Assets_Provider_Abstract
 
             $files = array();
             foreach ($paths as $p) {
-                $files = array_merge(array(
+                $files = array_merge($files, array(
+                    array(
+                        'file' => 'dist/'.$p.'.dist.js',
+                        'additionalFiles' => array(
+                            'dist/'.$p.'.dist.css',
+                        )
+                    ),
                     array(
                         'file' => $p.'.js',
                         'additionalFiles' => array(


### PR DESCRIPTION
This was needed for excel-builder. It was also needed to add this
at the first position because there is an excel-builder.js file at
root level using requireJS which doesn't work for us. We need to
work with "dist/excel-builder.dist.js"