### PR TITLE
Don't use static array to define fieldKey. Give option to set manually

### DIFF
--- a/Kwf/Form/Field/MultiCheckbox.php
+++ b/Kwf/Form/Field/MultiCheckbox.php
@@ -39,7 +39,7 @@ class Kwf_Form_Field_MultiCheckbox extends Kwf_Form_Field_Abstract
      *               - oder das RelationsModel selbst (Kwf_Model_Abstract)
      * @param string $relationToValuesRule Die rule vom Relationsmodel zum Values-model
      */
-    public function __construct($dependetModelRule, $relationToValuesRule, $title = null)
+    public function __construct($dependetModelRule, $relationToValuesRule, $title = null, $fieldKey = null)
     {
         if (!is_string($dependetModelRule)) {
             if (is_object($dependetModelRule) && !($dependetModelRule instanceof Kwf_Model_Abstract)) {
@@ -50,12 +50,7 @@ class Kwf_Form_Field_MultiCheckbox extends Kwf_Form_Field_Abstract
         $this->setValuesModel($relationToValuesRule);
         $this->_relationToValuesRule = $relationToValuesRule;
 
-        $fieldKey = $relationToValuesRule;
-        $i = 2;
-        while (in_array($fieldKey, self::$_multiCheckboxes)) {
-            $fieldKey = $relationToValuesRule.$i++;
-        }
-        self::$_multiCheckboxes[] = $fieldKey;
+        if (!$fieldKey) $fieldKey = $relationToValuesRule;
 
         parent::__construct($fieldKey);
         if ($title) {


### PR DESCRIPTION
Problem on page with multiple forms containing multicheckbox for same
relationToValuesRule. Results in deleting relation-rows in submited
form (no problem with the first form on page) after changing values.
The reason was that on page load every form is initialised and therefore
fieldKey for multicheckbox#2 is form_RELATION2_ID. In post-request only
posted form ist initialised and therefore multicheckbox in form#2 is called
form_RELATION_ID and does not match with post-variables with value
form_RELATION2_ID