### PR TITLE
Add debugging code that verifys Db buffer is written out correctly

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -72,6 +72,7 @@ debug.sendAllMailsBcc =
 debug.timeLimit = false
 debug.testPasswordAllowed = false
 debug.queryTimeout = false
+; debug.dbBuffer = false
 
 debug.duckcast.host = false
 debug.duckcast.port = 3800


### PR DESCRIPTION
If buffers are not written for some reason (error, script aborts etc) we get noticed about that.
Disabled by default