### PR TITLE
Allow kwfSessionToken as header Param

### DIFF
--- a/Kwf/Controller/Action.php
+++ b/Kwf/Controller/Action.php
@@ -49,10 +49,12 @@ abstract class Kwf_Controller_Action extends Zend_Controller_Action
     protected function _validateSessionToken()
     {
         if ($this->_helper->getHelper('viewRenderer')->isJson() && Kwf_Util_SessionToken::getSessionToken()) {
-            if (!$this->_getParam('kwfSessionToken')) {
-                throw new Kwf_Exception("Missing sessionToken parameter");
+            if (!$this->_getParam('kwfSessionToken') && !$this->getRequest()->getHeader('X-Kwf-Session-Token')) {
+                throw new Kwf_Exception("Missing sessionToken parameter or X-Kwf-Session-Token header");
             }
-            if ($this->_getParam('kwfSessionToken') != Kwf_Util_SessionToken::getSessionToken()) {
+            if (($this->_getParam('kwfSessionToken') != Kwf_Util_SessionToken::getSessionToken())
+                &&  ($this->getRequest()->getHeader('X-Kwf-Session-Token') != Kwf_Util_SessionToken::getSessionToken())
+            ) {
                 throw new Kwf_Exception("Invalid kwfSessionToken");
             }
         }

--- a/Kwf/Rest/Controller.php
+++ b/Kwf/Rest/Controller.php
@@ -47,10 +47,12 @@ abstract class Kwf_Rest_Controller extends Zend_Rest_Controller
     protected function _validateSessionToken()
     {
         if (Kwf_Util_SessionToken::getSessionToken()) {
-            if (!$this->_getParam('kwfSessionToken')) {
-                throw new Kwf_Exception("Missing sessionToken parameter");
+            if (!$this->_getParam('kwfSessionToken') && !$this->getRequest()->getHeader('X-Kwf-Session-Token')) {
+                throw new Kwf_Exception("Missing sessionToken parameter or X-Kwf-Session-Token header");
             }
-            if ($this->_getParam('kwfSessionToken') != Kwf_Util_SessionToken::getSessionToken()) {
+            if (($this->_getParam('kwfSessionToken') != Kwf_Util_SessionToken::getSessionToken())
+                &&  ($this->getRequest()->getHeader('X-Kwf-Session-Token') != Kwf_Util_SessionToken::getSessionToken())
+            ) {
                 throw new Kwf_Exception("Invalid kwfSessionToken");
             }
         }


### PR DESCRIPTION
This is useful for frontend developement with apis
e.g. jquery: use the setRequestHeader method in $.ajaxSend