### PR TITLE
JS-Parser: Concat all input before parsing js-code

### DIFF
--- a/Kwf/Trl/Parser/JsParser.js
+++ b/Kwf/Trl/Parser/JsParser.js
@@ -104,13 +104,12 @@ var parseContent = function(content, translations, contentLines) {
     recursiveCheckForTrl(esprima.parse(content, {loc: true}), translations, contentLines);
 };
 
-process.stdin.on('readable', function() {
-    var content = process.stdin.read();
-    if (content == null) return;
+var content = '';
+process.stdin.resume();
+prcoess.stdin.on('data', function (buf) { content += buf.toString(); });
+process.stdin.on('end', function() {
     var contentLines = content.split("\n");
     parseContent(content, translations, contentLines);
-});
-process.stdin.on('end', function() {
     console.log(JSON.stringify(translations));
     process.exit(0);
 });


### PR DESCRIPTION
If input is written in chunks only the first was parsed, resulting
in exception.