### PR TITLE
Column-Component responsive fix

### DIFF
--- a/Kwc/Columns/Component.scss
+++ b/Kwc/Columns/Component.scss
@@ -82,6 +82,10 @@ $grid-padding   : 0em;
             &.emptyContent {
                 display: none;
             }
+
+            &.kwcEven {
+                clear: left;
+            }
         }
     }
 
@@ -112,6 +116,10 @@ $grid-padding   : 0em;
 
             &.emptyContent {
                 display: inline;
+            }
+
+            &.kwcEven {
+                clear: none;
             }
         }
     }


### PR DESCRIPTION
When a column component with properties 25-25-25-25 is used and its parent is between 480 and 621 pixels wide, than it looks like a two column component. Problem is: when the content of the first element is higher than the second one, than the third element will move to the right edge, because of an missing "clear" setting in css. This commit should fix this wrong behavior.