### PR TITLE
AllowOnlyImages only allows png, gif and jpg

### DIFF
--- a/Kwf/Form/Field/File.php
+++ b/Kwf/Form/Field/File.php
@@ -84,9 +84,11 @@ class Kwf_Form_Field_File extends Kwf_Form_Field_SimpleAbstract
             if ($data) {
                 $fileModel = $row->getModel()->getReferencedModel($this->getName());
                 $row = $fileModel->getRow($data);
-                if ($this->getAllowOnlyImages() && substr($row->mime_type, 0, 6) !=  'image/') {
+                if ($this->getAllowOnlyImages()
+                    && !in_array($row->mime_type, array('image/png', 'image/gif', 'image/jpeg', 'image/jpg'))
+                ) {
                     $ret[] = array(
-                        'message' => trlKwf('This is not an image.'),
+                        'message' => trlKwf('Only png, gif and jpeg supported.'),
                         'field' => $this
                     );
                 }

--- a/Kwf_js/Form/File.js
+++ b/Kwf_js/Form/File.js
@@ -215,7 +215,7 @@ Kwf.Form.File = Ext2.extend(Ext2.form.Field, {
 
         var accept = '*';
         if (this.allowOnlyImages) {
-            accept = 'image/\*';
+            accept = 'image/png,image/jpg,image/jpeg,image/gif';
         }
         var fileInput = fileInputContainer.createChild({
             tag: 'input',


### PR DESCRIPTION
because other image types don't make sense on a website.