### PR TITLE
Implement sass mixin for Responsive El

### DIFF
--- a/Kwf/Assets/ResponsiveEl/JsDependency.php
+++ b/Kwf/Assets/ResponsiveEl/JsDependency.php
@@ -1,0 +1,22 @@
+<?php
+class Kwf_Assets_ResponsiveEl_JsDependency extends Kwf_Assets_Dependency_Abstract
+{
+    private $_selector;
+    private $_breakpoints;
+
+    public function __construct($selector, $breakpoints)
+    {
+        $this->_selector = $selector;
+        $this->_breakpoints = $breakpoints;
+    }
+
+    public function getMimeType()
+    {
+        return 'text/javascript';
+    }
+
+    public function getContents($language)
+    {
+        return "Kwf.Util.ResponsiveEl('".$this->_selector."', [".implode(',', $this->_breakpoints)."]);\n";
+    }
+}

--- a/Kwf/Assets/ResponsiveEl/Provider.php
+++ b/Kwf/Assets/ResponsiveEl/Provider.php
@@ -1,0 +1,31 @@
+<?php
+class Kwf_Assets_ResponsiveEl_Provider extends Kwf_Assets_Provider_Abstract
+{
+    public function getDependenciesForDependency(Kwf_Assets_Dependency_Abstract $dependency)
+    {
+        if ($dependency->getMimeType() == 'text/css') {
+            $contents = $dependency->getContents('en');
+            if (preg_match_all('#([^}{]*){[^}]*kwf-responsive-el-gt:\s*([0-9]+)#', $contents, $m)) {
+                $selectors = array();
+                foreach (array_keys($m[1]) as $k) {
+                    if (!isset($selectors[$m[1][$k]])) $selectors[$m[1][$k]] = array();
+                    $selectors[$m[1][$k]][] = $m[2][$k];
+                }
+                foreach ($selectors as $selector=>$breakpoints) {
+                    $d = new Kwf_Assets_ResponsiveEl_JsDependency($selector, $breakpoints);
+                    $d->addDependency(Kwf_Assets_Dependency_Abstract::DEPENDENCY_TYPE_REQUIRES, $this->_providerList->findDependency('KwfResponsiveEl'));
+                    $ret[] = $d;
+                }
+                return array(
+                    Kwf_Assets_Dependency_Abstract::DEPENDENCY_TYPE_REQUIRES => $ret
+                );
+            }
+        }
+        return array();
+    }
+
+    public function getDependency($dependencyName)
+    {
+        return null;
+    }
+}

--- a/sass/Kwf/stylesheets/kwf/_el-breakpoint.scss
+++ b/sass/Kwf/stylesheets/kwf/_el-breakpoint.scss
@@ -1,4 +1,4 @@
-@mixin responsive-el($gtWidth) {
+@mixin el-breakpoint($gtWidth) {
     @if unit($gtWidth) != 'px' {
       @error 'Invalid unit, only px supported';
     }

--- a/sass/Kwf/stylesheets/kwf/_responsive-el.scss
+++ b/sass/Kwf/stylesheets/kwf/_responsive-el.scss
@@ -1,0 +1,10 @@
+@mixin responsive-el($gtWidth) {
+    @if unit($gtWidth) != 'px' {
+      @error 'Invalid unit, only px supported';
+    }
+    $gtWidthUnitless: $gtWidth / ($gtWidth * 0 + 1);
+    &.gt#{$gtWidthUnitless} {
+      @content;
+    }
+    kwf-responsive-el-gt: $gtWidthUnitless;
+}

--- a/tests/Kwf/Assets/ResponsiveEl/Foo.scss
+++ b/tests/Kwf/Assets/ResponsiveEl/Foo.scss
@@ -1,0 +1,17 @@
+@import "kwf/responsive-el";
+
+.test123 {
+  @include responsive-el(350px) {
+    p  { color: red; }
+  }
+}
+.test123 {
+  @include responsive-el(400px) {
+    p  { color: blue; }
+  }
+}
+.test456 {
+  @include responsive-el(350px) {
+    p  { color: green; }
+  }
+}

--- a/tests/Kwf/Assets/ResponsiveEl/Foo.scss
+++ b/tests/Kwf/Assets/ResponsiveEl/Foo.scss
@@ -1,17 +1,17 @@
-@import "kwf/responsive-el";
+@import "kwf/el-breakpoint";
 
 .test123 {
-  @include responsive-el(350px) {
+  @include el-breakpoint(350px) {
     p  { color: red; }
   }
 }
 .test123 {
-  @include responsive-el(400px) {
+  @include el-breakpoint(400px) {
     p  { color: blue; }
   }
 }
 .test456 {
-  @include responsive-el(350px) {
+  @include el-breakpoint(350px) {
     p  { color: green; }
   }
 }

--- a/tests/Kwf/Assets/ResponsiveEl/Test.php
+++ b/tests/Kwf/Assets/ResponsiveEl/Test.php
@@ -1,0 +1,32 @@
+<?php
+class Kwf_Assets_ResponsiveEl_Test extends Kwf_Test_TestCase
+{
+    private $_list;
+    public function setUp()
+    {
+        parent::setUp();
+        $this->_list = new Kwf_Assets_ResponsiveEl_TestProviderList();
+    }
+
+    public function testDep()
+    {
+        $d = $this->_list->findDependency('Foo');
+        $deps = $d->getRecursiveDependencies();
+        $ok = false;
+        foreach ($deps as $i) {
+            if ($i instanceof Kwf_Assets_ResponsiveEl_JsDependency) {
+                $ok = true;
+            }
+        }
+        $this->assertTrue($ok);
+
+    }
+    public function testPackage()
+    {
+        $package = new Kwf_Assets_Package($this->_list, 'Foo');
+        $c = $package->getPackageContents('text/javascript', 'en', 0, false)->getFileContents();
+        $this->assertContains("ResponsiveEl('.test123', [350,400])", $c);
+        $this->assertContains("ResponsiveEl('.test456', [350])", $c);
+    }
+
+}

--- a/tests/Kwf/Assets/ResponsiveEl/TestDependencies.ini
+++ b/tests/Kwf/Assets/ResponsiveEl/TestDependencies.ini
@@ -1,0 +1,2 @@
+[dependencies]
+Foo.files[] = kwf/tests/Kwf/Assets/ResponsiveEl/Foo.scss

--- a/tests/Kwf/Assets/ResponsiveEl/TestProviderList.php
+++ b/tests/Kwf/Assets/ResponsiveEl/TestProviderList.php
@@ -1,0 +1,14 @@
+<?php
+class Kwf_Assets_ResponsiveEl_TestProviderList extends Kwf_Assets_ProviderList_Abstract
+{
+    public function __construct()
+    {
+        $providers = array(
+//             new Kwf_Assets_Provider_JsClass(KWF_PATH.'/tests', 'kwf/tests'),
+        );
+        $providers = array_merge($providers, self::getVendorProviders());
+        $providers[] = new Kwf_Assets_ResponsiveEl_Provider();
+        $providers[] = new Kwf_Assets_Provider_Ini(dirname(__FILE__).'/TestDependencies.ini');
+        parent::__construct($providers);
+    }
+}


### PR DESCRIPTION
JavaScript is generated based on mixin output. This avoids the need for Component.js containing ResponsiveEl only.

usage example:

    .cssClass {
      @include responsive-el(350px) {
        p  { color: red; }
      }
    }