### PR TITLE
Remove printcss assets filetype

### DIFF
--- a/Kwc/Advanced/GoogleMapView/Component.printcss
+++ b/Kwc/Advanced/GoogleMapView/Component.printcss
@@ -1,3 +1,0 @@
-.cssClass {
-    page-break-before: always;
-}

--- a/Kwc/Advanced/GoogleMapView/Component.scss
+++ b/Kwc/Advanced/GoogleMapView/Component.scss
@@ -28,3 +28,10 @@
 .cssClass .mapDirSuggestParent { display: none; margin-top: 30px; }
 
 .cssClass .container { overflow: hidden; border: 1px solid #000; }
+
+@media print {
+.cssClass {
+    page-break-before: always;
+}
+
+}

--- a/Kwc/Articles/Detail/Component.css
+++ b/Kwc/Articles/Detail/Component.css
@@ -34,3 +34,12 @@
 .cssClass .article .icons .kwfSwitchHoverFade .switchContent {
     display: none;
 }
+
+@media print {
+.cssClass .feedback,
+.cssClass .back,
+.cssClass .icons {
+    display: none;
+}
+
+}

--- a/Kwc/Articles/Detail/Component.printcss
+++ b/Kwc/Articles/Detail/Component.printcss
@@ -1,5 +1,0 @@
-.cssClass .feedback,
-.cssClass .back,
-.cssClass .icons {
-    display: none;
-}

--- a/Kwc/Basic/ImageEnlarge/Component.printcss
+++ b/Kwc/Basic/ImageEnlarge/Component.printcss
@@ -1,4 +1,0 @@
-.cssClass a .outerHoverIcon {
-    width: 0px;
-    height: 0px;
-}

--- a/Kwc/Basic/ImageEnlarge/Component.scss
+++ b/Kwc/Basic/ImageEnlarge/Component.scss
@@ -84,3 +84,10 @@ body.ext2-ie8 .cssClass a {
         display: block;
     }
 }
+
+@media print {
+.cssClass a .outerHoverIcon {
+    width: 0px;
+    height: 0px;
+}
+}

--- a/Kwc/Paging/Abstract/Component.css
+++ b/Kwc/Paging/Abstract/Component.css
@@ -21,3 +21,8 @@
 }
 
 .cssClass span { font-weight: bold; }
+
+@media print {
+.cssClass { display: none; }
+
+}

--- a/Kwc/Paging/Abstract/Component.printcss
+++ b/Kwc/Paging/Abstract/Component.printcss
@@ -1,1 +1,0 @@
-.cssClass { display: none; }

--- a/Kwc/Tags/Component.scss
+++ b/Kwc/Tags/Component.scss
@@ -1,3 +1,7 @@
+
+@media print {
 .cssClass form {
     display: none;
+}
+
 }

--- a/Kwf/Assets/Dependency/File.php
+++ b/Kwf/Assets/Dependency/File.php
@@ -118,8 +118,6 @@ class Kwf_Assets_Dependency_File extends Kwf_Assets_Dependency_Abstract
             $ret = new Kwf_Assets_Dependency_File_Js($fileName);
         } else if (substr($fileName, -4) == '.css') {
             $ret = new Kwf_Assets_Dependency_File_Css($fileName);
-        } else if (substr($fileName, -9) == '.printcss') {
-            $ret = new Kwf_Assets_Dependency_File_PrintCss($fileName);
         } else if (substr($fileName, -5) == '.scss') {
             $ret = new Kwf_Assets_Dependency_File_Scss($fileName);
         } else if (substr($fileName, -2) == '/*') {
@@ -177,9 +175,6 @@ class Kwf_Assets_Dependency_File extends Kwf_Assets_Dependency_Abstract
         }
         if (substr($cssClass, -3) == '.js') {
             $cssClass = substr($cssClass, 0, -3);
-        }
-        if (substr($cssClass, -9) == '.printcss') {
-            $cssClass = substr($cssClass, 0, -9);
         }
         if (substr($cssClass, -10) == '/Component') {
             $cssClass = substr($cssClass, 0, -10);

--- a/Kwf/Assets/Dependency/File/PrintCss.php
+++ b/Kwf/Assets/Dependency/File/PrintCss.php
@@ -1,8 +1,0 @@
-<?php
-class Kwf_Assets_Dependency_File_PrintCss extends Kwf_Assets_Dependency_File_Css
-{
-    public function getMimeType()
-    {
-        return 'text/css; media=print';
-    }
-}

--- a/Kwf/Assets/Dispatcher.php
+++ b/Kwf/Assets/Dispatcher.php
@@ -156,7 +156,6 @@ class Kwf_Assets_Dispatcher
         }
         if ($extension == 'js') $mimeType = 'text/javascript';
         else if ($extension == 'css') $mimeType = 'text/css';
-        else if ($extension == 'printcss') $mimeType = 'text/css; media=print';
         else if ($extension == 'defer.js') $mimeType = 'text/javascript; defer';
         else throw new Kwf_Exception_NotFound();
 
@@ -164,7 +163,7 @@ class Kwf_Assets_Dispatcher
             $contents = $package->getPackageContents($mimeType, $language)->getFileContents();
             $mtime = $package->getMaxMTime($mimeType);
             if ($extension == 'js' || $extension == 'defer.js') $mimeType = 'text/javascript; charset=utf-8';
-            else if ($extension == 'css' || $extension == 'printcss') $mimeType = 'text/css; charset=utf-8';
+            else if ($extension == 'css') $mimeType = 'text/css; charset=utf-8';
         } else {
             $contents = $package->getPackageContents($mimeType, $language)->getMapContents(false);
             $mtime = $package->getMaxMTime($mimeType);

--- a/Kwf/Assets/Loader.php
+++ b/Kwf/Assets/Loader.php
@@ -32,9 +32,6 @@ class Kwf_Assets_Loader
         } else if (substr($file, -4)=='.css' || substr($file, -5)=='.scss') {
             $ret['mimeType'] = 'text/css; charset=utf-8';
             if (!Kwf_Assets_Dispatcher::allowSourceAccess()) throw new Kwf_Exception_AccessDenied();
-        } else if (substr($file, -9)=='.printcss') {
-            $ret['mimeType'] = 'text/css; charset=utf-8';
-            if (!Kwf_Assets_Dispatcher::allowSourceAccess()) throw new Kwf_Exception_AccessDenied();
         } else if (substr($file, -3)=='.js') {
             $ret['mimeType'] = 'text/javascript; charset=utf-8';
             if (!Kwf_Assets_Dispatcher::allowSourceAccess()) throw new Kwf_Exception_AccessDenied();

--- a/Kwf/Assets/Package.php
+++ b/Kwf/Assets/Package.php
@@ -102,7 +102,6 @@ class Kwf_Assets_Package
         if ($mimeType == 'text/javascript') $ext = 'js';
         else if ($mimeType == 'text/javascript; defer') $ext = 'defer.js';
         else if ($mimeType == 'text/css') $ext = 'css';
-        else if ($mimeType == 'text/css; media=print') $ext = 'printcss';
 
         $cacheId = Kwf_Assets_Dispatcher::getCacheIdByPackage($this, $ext, $language);
         $ret = Kwf_Assets_BuildCache::getInstance()->load($cacheId);
@@ -165,7 +164,6 @@ class Kwf_Assets_Package
         if ($mimeType == 'text/javascript') $ext = 'js';
         else if ($mimeType == 'text/javascript; defer') $ext = 'defer.js';
         else if ($mimeType == 'text/css') $ext = 'css';
-        else if ($mimeType == 'text/css; media=print') $ext = 'printcss';
         $packageMap->setFile($this->getPackageUrl($ext, $language));
 
         // ***** commonjs
@@ -236,11 +234,10 @@ class Kwf_Assets_Package
             if ($mimeType == 'text/javascript') $ext = 'js';
             else if ($mimeType == 'text/javascript; defer') $ext = 'defer.js';
             else if ($mimeType == 'text/css') $ext = 'css';
-            else if ($mimeType == 'text/css; media=print') $ext = 'printcss';
             else throw new Kwf_Exception_NotYetImplemented();
             if ($ext == 'js' || $ext == 'defer.js') {
                 $contents .= "\n//# sourceMappingURL=".$this->getPackageUrl($ext.'.map', $language)."\n";
-            } else if ($ext == 'css' || $ext == 'printcss') {
+            } else if ($ext == 'css') {
                 $contents .= "\n/*# sourceMappingURL=".$this->getPackageUrl($ext.'.map', $language)." */\n";
             }
             $packageMap->setFileContents($contents);
@@ -294,7 +291,6 @@ class Kwf_Assets_Package
         if ($mimeType == 'text/javascript') $ext = 'js';
         else if ($mimeType == 'text/javascript; defer') $ext = 'defer.js';
         else if ($mimeType == 'text/css') $ext = 'css';
-        else if ($mimeType == 'text/css; media=print') $ext = 'printcss';
         else throw new Kwf_Exception_NotYetImplemented();
 
         $ret = array();

--- a/Kwf/Assets/Provider/Components.php
+++ b/Kwf/Assets/Provider/Components.php
@@ -25,7 +25,6 @@ class Kwf_Assets_Provider_Components extends Kwf_Assets_Provider_Abstract
             $nonDeferDep = array();
             $files = Kwf_Component_Abstract_Admin::getComponentFiles($this->_rootComponentClass, array(
                 'css' => array('filename'=>'Web', 'ext'=>'css', 'returnClass'=>false, 'multiple'=>true),
-                'printcss' => array('filename'=>'Web', 'ext'=>'printcss', 'returnClass'=>false, 'multiple'=>true),
                 'scss' => array('filename'=>'Web', 'ext'=>'scss', 'returnClass'=>false, 'multiple'=>true),
             ));
             foreach ($files as $i) {
@@ -59,7 +58,7 @@ class Kwf_Assets_Provider_Components extends Kwf_Assets_Provider_Abstract
                 //alle dateien der vererbungshierache includieren
                 $files = Kwc_Abstract::getSetting($class, 'componentFiles');
                 $componentCssFiles = array();
-                foreach (array_merge($files['css'], $files['printcss'], $files['js'], $files['masterCss']) as $f) {
+                foreach (array_merge($files['css'], $files['js'], $files['masterCss']) as $f) {
                     $componentCssFiles[] = $f;
                 }
                 //reverse damit css von weiter unten in der vererbungshierachie überschreibt

--- a/Kwf/Component/Settings.php
+++ b/Kwf/Component/Settings.php
@@ -139,7 +139,7 @@ class Kwf_Component_Settings
                 $file .= '/Component';
             }
             foreach ($dirs as $dir) {
-                if (is_file($dir.'/'.$file.'.css') || is_file($dir.'/'.$file.'.scss') || is_file($dir.'/'.$file.'.printcss') || is_file($dir.'/'.$file.'.js') || is_file($dir.'/'.$file.'.defer.js')) {
+                if (is_file($dir.'/'.$file.'.css') || is_file($dir.'/'.$file.'.scss') || is_file($dir.'/'.$file.'.js') || is_file($dir.'/'.$file.'.defer.js')) {
                     $cssClass[] = Kwf_Component_Abstract::formatCssClass($i);
                     break;
                 }
@@ -244,7 +244,6 @@ class Kwf_Component_Settings
 
                     //verwendet bei dependencies
                     'css' => array('filename'=>'Component', 'ext'=>array('css', 'scss'), 'returnClass'=>false, 'multiple'=>true),
-                    'printcss' => array('filename'=>'Component', 'ext'=>'printcss', 'returnClass'=>false, 'multiple'=>true),
                     'masterCss' => array('filename'=>'Master', 'ext'=>array('css', 'scss'), 'returnClass'=>false, 'multiple'=>true),
                     'js' => array('filename'=>'Component', 'ext'=>array('js', 'defer.js'), 'returnClass'=>false, 'multiple'=>true),
                 ));

--- a/Kwf/Controller/Action/Debug/AssetsDependenciesController.php
+++ b/Kwf/Controller/Action/Debug/AssetsDependenciesController.php
@@ -105,10 +105,6 @@ class Kwf_Controller_Action_Debug_AssetsDependenciesController extends Kwf_Contr
                     $f = $type . '/' . $file.'.css';
                     $this->_processDependencyFile($assetsType, $f);
                 }
-                if (is_file($dir . '/' . $file.'.printcss')) {
-                    $f = $type . '/' . $file.'.printcss';
-                    $this->_processDependencyFile($assetsType, $f);
-                }
             }
         }
 

--- a/Kwf/Util/ClearCache/Watcher.php
+++ b/Kwf/Util/ClearCache/Watcher.php
@@ -165,7 +165,7 @@ class Kwf_Util_ClearCache_Watcher
     {
         $eventStart = microtime(true);
         Kwf_Cache_Simple::resetZendCache(); //reset to re-fetch namespace
-        if (substr($event->filename, -4)=='.css' || substr($event->filename, -3)=='.js' || substr($event->filename, -9)=='.printcss' || substr($event->filename, -5)=='.scss') {
+        if (substr($event->filename, -4)=='.css' || substr($event->filename, -3)=='.js' || substr($event->filename, -5)=='.scss') {
             echo "asset modified\n";
             if ($event instanceof Event\Modify) {
 
@@ -299,8 +299,7 @@ class Kwf_Util_ClearCache_Watcher
                        self::_endsWith($event->filename, '/FrontendForm.php') ||
                        self::_endsWith($event->filename, '/Form.php') ||
                        self::_endsWith($event->filename, '/Component.css') ||
-                       self::_endsWith($event->filename, '/Component.scss') ||
-                       self::_endsWith($event->filename, '/Component.printcss')
+                       self::_endsWith($event->filename, '/Component.scss')
             ) {
                 if ($event instanceof Event\Create || $event instanceof Event\Delete) {
                     echo "recalculate 'componentFiles' setting because comopnent file got removed/added...\n";
@@ -319,7 +318,7 @@ class Kwf_Util_ClearCache_Watcher
                     $s->whereEquals('component_class', $matchingClasses);
                     self::_deleteViewCache($s);
                 }
-            } else if (self::_endsWith($event->filename, '/Component.css') || self::_endsWith($event->filename, '/Component.scss') || self::_endsWith($event->filename, '/Component.printcss')) {
+            } else if (self::_endsWith($event->filename, '/Component.css') || self::_endsWith($event->filename, '/Component.scss')) {
                 //MODIFY already handled above (assets)
                 //CREATE/DELETE also handled above
             } else if (self::_endsWith($event->filename, '/Master.tpl') || self::_endsWith($event->filename, '/Master.twig')) {
@@ -573,7 +572,6 @@ class Kwf_Util_ClearCache_Watcher
             self::_clearAssetsAll('js');
             self::_clearAssetsAll('defer.js');
             self::_clearAssetsAll('css');
-            self::_clearAssetsAll('printcss');
             return;
         }
         $fileNames = array(

--- a/Kwf/View/Helper/Assets.php
+++ b/Kwf/View/Helper/Assets.php
@@ -10,11 +10,6 @@ class Kwf_View_Helper_Assets
         foreach ($assetsPackage->getPackageUrls('text/css', $language) as $file) {
             $ret .= "$indent<link rel=\"stylesheet\" type=\"text/css\" href=\"".htmlspecialchars($file)."\" />\n";
         }
-        foreach ($assetsPackage->getPackageUrls('text/css; media=print', $language) as $file) {
-            $ret .= "$indent<link rel=\"stylesheet\" type=\"text/css\" href=\"".htmlspecialchars($file)."\" ";
-            $ret .= "media=\"print\" ";
-            $ret .= "/>\n";
-        }
         foreach ($assetsPackage->getPackageUrls('text/javascript', $language) as $file) {
             $ret .= "$indent<script type=\"text/javascript\" src=\"".htmlspecialchars($file)."\"></script>\n";
         }


### PR DESCRIPTION
Instead use @media print which is supported in IE9+
This change is possible since we don't support IE8 anymore.

kwf-upgrade script will automatically convert all .printcss