### PR TITLE
Improve handling of sibling rows in Union Model

### DIFF
--- a/Kwf/Model/Db.php
+++ b/Kwf/Model/Db.php
@@ -280,7 +280,7 @@ class Kwf_Model_Db extends Kwf_Model_Abstract
         return $dbSelect;
     }
 
-    protected function _applySelect(Zend_Db_Select $dbSelect, Kwf_Model_Select $select)
+    public function _applySelect(Zend_Db_Select $dbSelect, Kwf_Model_Select $select)
     {
         if ($dbSelect instanceof Zend_Db_Table_Select) {
             $dbSelect->setIntegrityCheck(false);
@@ -649,7 +649,9 @@ class Kwf_Model_Db extends Kwf_Model_Abstract
             if (!$depSelect) $depSelect = new Kwf_Model_Select();
 
             if ($dbDepM instanceof Kwf_Model_Union) {
-                $depDbSelect = $dbDepM->getDbSelects($depSelect, array($ref['column']));
+                $depDbSelects = $dbDepM->getDbSelects($depSelect, array($ref['column']));
+                $depDbSelect = Kwf_Registry::get('db')->select();
+                $depDbSelect->union($depDbSelects);
             } elseif ($dbDepM instanceof Kwf_Model_Db) {
                 $col1 = $dbDepM->_formatField($ref['column'], null /* select fehlt - welches ist das korrekte?*/);
                 $depDbSelect = $dbDepM->_getDbSelect($depSelect);

--- a/tests/Kwf/Model/Union/Abstract/Test.php
+++ b/tests/Kwf/Model/Union/Abstract/Test.php
@@ -153,6 +153,17 @@ abstract class Kwf_Model_Union_Abstract_Test extends Kwf_Test_TestCase
         $this->assertEquals('1m2', $rows[0]->id);
     }
 
+    public function testGetRowsSiblingEqualsBool()
+    {
+        $s = new Kwf_Model_Select();
+        $s->where(new Kwf_Model_Select_Expr_Or(array(
+            new Kwf_Model_Select_Expr_Equal('sib_bool', 0),
+            new Kwf_Model_Select_Expr_IsNull('sib_bool')
+        )));
+        $this->assertEquals(4, count($this->_m->getRows($s)));
+        $this->assertEquals(4, $this->_m->countRows($s));
+    }
+
     public function testGetIdsOrder()
     {
         $s = new Kwf_Model_Select();
@@ -278,11 +289,11 @@ abstract class Kwf_Model_Union_Abstract_Test extends Kwf_Test_TestCase
     {
         $row = $this->_m->getRow('1m2');
         $a = $row->toArray();
-        $this->assertEquals(array('id' => '1m2', 'foo' => '2', 'bar' => '2', 'baz' => '2', 'sib' => 'ss2'), $a);
+        $this->assertEquals(array('id' => '1m2', 'foo' => '2', 'bar' => '2', 'baz' => '2', 'sib' => 'ss2', 'sib_bool' => false), $a);
 
         $row = $this->_m->getRow('2m2');
         $a = $row->toArray();
-        $this->assertEquals(array('id' => '2m2', 'foo' => '333', 'bar' => 'yy1', 'baz' => null, 'sib' => 'sss3'), $a);
+        $this->assertEquals(array('id' => '2m2', 'foo' => '333', 'bar' => 'yy1', 'baz' => null, 'sib' => 'sss3', 'sib_bool' => true), $a);
     }
 
     public function testEmptyMappingColumn1()

--- a/tests/Kwf/Model/Union/Db/ModelSibling.php
+++ b/tests/Kwf/Model/Union/Db/ModelSibling.php
@@ -20,15 +20,16 @@ class Kwf_Model_Union_Db_ModelSibling extends Kwf_Model_Db
     {
         Kwf_Registry::get('db')->query("CREATE TABLE IF NOT EXISTS {$this->_tableName} (
             `id`  VARCHAR( 100 ) NOT NULL PRIMARY KEY ,
-            `sib` VARCHAR( 255 ) NULL
+            `sib` VARCHAR( 255 ) NULL,
+            `sib_bool` tinyint(1) NOT NULL default '0'
         ) ENGINE = INNODB");
         Kwf_Registry::get('db')->query("TRUNCATE TABLE {$this->_tableName}");
         Kwf_Registry::get('db')->query("INSERT INTO {$this->_tableName}
-                        (id, sib) VALUES ('1m1', 's1')");
+                        (id, sib, sib_bool) VALUES ('1m1', 's1', 1)");
         Kwf_Registry::get('db')->query("INSERT INTO {$this->_tableName}
-                        (id, sib) VALUES ('1m2', 'ss2')");
+                        (id, sib, sib_bool) VALUES ('1m2', 'ss2', 0)");
         Kwf_Registry::get('db')->query("INSERT INTO {$this->_tableName}
-                        (id, sib) VALUES ('2m2', 'sss3')");
+                        (id, sib, sib_bool) VALUES ('2m2', 'sss3', 1)");
     }
 
     public function dropTable()

--- a/tests/Kwf/Model/Union/DbWithExpr/Test.php
+++ b/tests/Kwf/Model/Union/DbWithExpr/Test.php
@@ -39,11 +39,11 @@ class Kwf_Model_Union_DbWithExpr_Test extends Kwf_Model_Union_Abstract_Test
     {
         $row = $this->_m->getRow('1m2');
         $a = $row->toArray();
-        $this->assertEquals(array('id' => '1m2', 'foo' => '2', 'bar' => '2', 'baz' => '2', 'sib' => 'ss2'), $a);
+        $this->assertEquals(array('id' => '1m2', 'foo' => '2', 'bar' => '2', 'baz' => '2', 'sib' => 'ss2', 'sib_bool' => 0), $a);
 
         $row = $this->_m->getRow('2m2');
         $a = $row->toArray();
-        $this->assertEquals(array('id' => '2m2', 'foo' => '333', 'bar' => 'yy1', 'baz' => 'foobar', 'sib' => 'sss3'), $a);
+        $this->assertEquals(array('id' => '2m2', 'foo' => '333', 'bar' => 'yy1', 'baz' => 'foobar', 'sib' => 'sss3', 'sib_bool' => 1), $a);
     }
 }
 

--- a/tests/Kwf/Model/Union/DeletedFlag/Model2.php
+++ b/tests/Kwf/Model/Union/DeletedFlag/Model2.php
@@ -2,7 +2,7 @@
 class Kwf_Model_Union_DeletedFlag_Model2 extends Kwf_Model_FnF
 {
     protected $_columnMappings = array(
-        'Kwf_Model_Union_FnF_TestMapping' => array(
+        'Kwf_Model_Union_DeletedFlag_TestMapping' => array(
         )
     );
     protected $_data = array(

--- a/tests/Kwf/Model/Union/FnF/ModelSibling.php
+++ b/tests/Kwf/Model/Union/FnF/ModelSibling.php
@@ -8,8 +8,8 @@ class Kwf_Model_Union_FnF_ModelSibling extends Kwf_Model_FnF
         )
     );
     protected $_data = array(
-        array('id' => '1m1', 'sib' => 's1'),
-        array('id' => '1m2', 'sib' => 'ss2'),
-        array('id' => '2m2', 'sib' => 'sss3'),
+        array('id' => '1m1', 'sib' => 's1', 'sib_bool' => 1),
+        array('id' => '1m2', 'sib' => 'ss2', 'sib_bool' => 0),
+        array('id' => '2m2', 'sib' => 'sss3', 'sib_bool' => 1),
     );
 }


### PR DESCRIPTION
Support IsNull-Expression for Sibling Row - even though sibling row doesn't exists, parent row has to be returned