### PR TITLE
Change implementation of how inherited Component styles are applied

### DIFF
--- a/Kwc/Abstract.php
+++ b/Kwc/Abstract.php
@@ -387,12 +387,8 @@ abstract class Kwc_Abstract extends Kwf_Component_Abstract
         if (!$up) {
             $ret['bemClasses'] = false;
         } else {
-            $classes = Kwc_Abstract::getSetting($this->getData()->componentClass, 'processedRootElementClass');;
-            $classes = explode(' ', $classes);
             $ret['bemClasses'] = array();
-            foreach ($classes as $i) {
-                $ret['bemClasses'][] = $i.'__';
-            }
+            $ret['bemClasses'][] = Kwf_Component_Abstract::formatRootElementClass($i, '').'__';
         }
 
         $ret['data'] = $this->getData();
@@ -529,7 +525,7 @@ abstract class Kwc_Abstract extends Kwf_Component_Abstract
         if (self::hasSetting($component, 'rootElementClass')) {
             $ret .= self::getSetting($component, 'rootElementClass').' ';
         }
-        $ret .= self::getSetting($component, 'processedRootElementClass');
+        $ret .= Kwf_Component_Abstract::formatRootElementClass($component, '');
         return $ret;
     }
 

--- a/Kwf/Assets/Components/Dependency/Abstract.php
+++ b/Kwf/Assets/Components/Dependency/Abstract.php
@@ -1,0 +1,71 @@
+<?php
+class Kwf_Assets_Components_Dependency_Abstract extends Kwf_Assets_Dependency_Abstract
+{
+    protected $_componentClass;
+    protected $_componentDependencies;
+
+    public function __construct($componentClass, array $componentDependencies)
+    {
+        $this->_componentClass = $componentClass;
+        $this->_componentDependencies = $componentDependencies;
+    }
+
+    private function _getKwcClass()
+    {
+        $kwcClass = Kwf_Component_Abstract::formatRootElementClass($this->_componentClass, '');
+        if (Kwf_Config::getValue('application.uniquePrefix')) {
+            $kwcClass = str_replace('kwfUp-', Kwf_Config::getValue('application.uniquePrefix'), $kwcClass);
+        } else {
+            $kwcClass = str_replace('kwfUp-', '', $kwcClass);
+        }
+        return $kwcClass;
+    }
+
+    public function getMTime()
+    {
+        $ret = null;
+        foreach ($this->_componentDependencies as $dep) {
+            $ret = max($ret, $dep->getMTime());
+        }
+        return $ret;
+    }
+
+    public function getContents($language)
+    {
+        $ret = '';
+        foreach ($this->_componentDependencies as $dep) {
+            $c = $dep->getContents($language);
+            if (Kwf_Config::getValue('application.uniquePrefix')) {
+                $c = str_replace('.kwcClass .kwcBem__', '.kwcBem__', $c);
+                $c = str_replace('kwcBem__', $this->_getKwcClass().'__', $c);
+            } else {
+                $c = str_replace('kwcBem__', '', $c);
+            }
+            $c = str_replace('.kwcClass', '.'.$this->_getKwcClass(), $c);
+            $ret .= $c;
+        }
+        return $ret;
+    }
+
+    public function getContentsPacked($language)
+    {
+        $ret = Kwf_SourceMaps_SourceMap::createEmptyMap('');
+        foreach ($this->_componentDependencies as $dep) {
+            $c = $dep->getContentsPacked($language);
+            if (Kwf_Config::getValue('application.uniquePrefix')) {
+                $c->stringReplace('.kwcClass .kwcBem__', '.kwcBem__');
+                $c->stringReplace('kwcBem__', $this->_getKwcClass().'__');
+            } else {
+                $c->stringReplace('kwcBem__', '');
+            }
+            $c->stringReplace('.kwcClass', '.'.$this->_getKwcClass());
+            $ret->concat($c);
+        }
+        return $ret;
+    }
+
+
+
+
+
+}

--- a/Kwf/Assets/Components/Dependency/Css.php
+++ b/Kwf/Assets/Components/Dependency/Css.php
@@ -1,0 +1,13 @@
+<?php
+class Kwf_Assets_Components_Dependency_Css extends Kwf_Assets_Components_Dependency_Abstract
+{
+    public function getMimeType()
+    {
+        return 'text/css';
+    }
+
+    public function __toString()
+    {
+        return $this->_componentClass.'-css';
+    }
+}

--- a/Kwf/Assets/Components/Dependency/Js.php
+++ b/Kwf/Assets/Components/Dependency/Js.php
@@ -1,0 +1,22 @@
+<?php
+class Kwf_Assets_Components_Dependency_Js extends Kwf_Assets_Components_Dependency_Abstract
+{
+    public function getMimeType()
+    {
+        return 'text/javascript';
+    }
+
+    public function isCommonJsEntry()
+    {
+        return true;
+    }
+
+    public function __toString()
+    {
+        $ret = $this->_componentClass.'-js';
+        if ($this->getDeferLoad()) {
+            $ret .= ' defer';
+        }
+        return $ret;
+    }
+}

--- a/Kwf/Assets/Dependency/File/Css.php
+++ b/Kwf/Assets/Dependency/File/Css.php
@@ -37,20 +37,6 @@ class Kwf_Assets_Dependency_File_Css extends Kwf_Assets_Dependency_File
                 $ret = str_replace('kwfUp-', '', $ret);
             }
         }
-        if (strpos($ret, 'kwcBem__') !== false) {
-            if (Kwf_Config::getValue('application.uniquePrefix')) {
-                $ret = str_replace('.kwcClass .kwcBem__', '.kwcBem__', $ret);
-                $ret = str_replace('kwcBem__', $this->_getComponentCssClass('css-').'__', $ret);
-            } else {
-                $ret = str_replace('kwcBem__', '', $ret);
-            }
-        }
-        if (strpos($ret, '.kwcClass') !== false) {
-            $cssClass = $this->_getComponentCssClass('css-');
-            if ($cssClass) {
-                $ret = str_replace('.kwcClass', '.'.$cssClass, $ret);
-            }
-        }
         return $ret;
     }
 

--- a/Kwf/Assets/Dependency/File/Js.php
+++ b/Kwf/Assets/Dependency/File/Js.php
@@ -27,9 +27,7 @@ class Kwf_Assets_Dependency_File_Js extends Kwf_Assets_Dependency_File
         $rawContents = $this->_getRawContents(null);
 
 
-        $usesUniquePrefix = strpos($rawContents, '.kwcClass') !== false
-            || strpos($rawContents, 'kwfUp-') !== false
-            || strpos($rawContents, 'kwcBem__') !== false;
+        $usesUniquePrefix = strpos($rawContents, 'kwfUp-') !== false;
 
         $pathType = $this->getType();
         if ($pathType == 'ext2' && strpos($rawContents, 'ext2-gen') !== false) {
@@ -71,26 +69,11 @@ class Kwf_Assets_Dependency_File_Js extends Kwf_Assets_Dependency_File
                         $map->stringReplace('ext2-gen', $uniquePrefix.'-ext2-gen');
                     }
                 }
-                $cssClass = $this->_getComponentCssClass('js-');
-                if ($cssClass) {
-                    if (preg_match_all('#([\'"])\.kwcClass([\s\'"\.])#', $contents, $m)) {
-                        foreach ($m[0] as $k=>$i) {
-                            $replacements[$i] = $m[1][$k].'.'.$cssClass.$m[2][$k];
-                        }
-                    }
-                }
                 if (strpos($rawContents, 'kwfUp-') !== false) {
                     if (Kwf_Config::getValue('application.uniquePrefix')) {
                         $replacements['kwfUp-'] = Kwf_Config::getValue('application.uniquePrefix').'-';
                     } else {
                         $replacements['kwfUp-'] = '';
-                    }
-                }
-                if (strpos($rawContents, 'kwcBem__') !== false) {
-                    if (Kwf_Config::getValue('application.uniquePrefix')) {
-                        $replacements['kwcBem__'] = $this->_getComponentCssClass('js-').'__';
-                    } else {
-                        $replacements['kwcBem__'] = '';
                     }
                 }
             }

--- a/Kwf/Assets/Dependency/File/Scss.php
+++ b/Kwf/Assets/Dependency/File/Scss.php
@@ -4,7 +4,7 @@ class Kwf_Assets_Dependency_File_Scss extends Kwf_Assets_Dependency_File_Css
     private function _getCacheFileName()
     {
         $fileName = $this->getFileNameWithType();
-        return 'cache/scss/v3'.str_replace(array('\\', ':', '/', '.', '-'), '_', $fileName);
+        return 'cache/scss/v4'.str_replace(array('\\', ':', '/', '.', '-'), '_', $fileName);
     }
 
     private static function _getAbsolutePath($path)
@@ -127,22 +127,6 @@ class Kwf_Assets_Dependency_File_Scss extends Kwf_Assets_Dependency_File_Css
                     $map->stringReplace('kwfUp-', Kwf_Config::getValue('application.uniquePrefix').'-');
                 } else {
                     $map->stringReplace('kwfUp-', '');
-                }
-            }
-            if (strpos($ret, 'kwcBem__') !== false) {
-                if (Kwf_Config::getValue('application.uniquePrefix')) {
-                    $map->stringReplace('.kwcClass .kwcBem__', '.kwcBem__');
-                    $map->stringReplace('kwcBem__', $this->_getComponentCssClass('css-').'__');
-                } else {
-                    $map->stringReplace('kwcBem__', '');
-                }
-            }
-            if (strpos($ret, '.kwcClass') !== false) {
-                $cssClass = $this->_getComponentCssClass('css-');
-                if ($cssClass) {
-                    if (strpos($ret, '.kwcClass') !== false) {
-                        $map->stringReplace('.kwcClass', ".$cssClass");
-                    }
                 }
             }
 

--- a/Kwf/Assets/Package/TestPackage.php
+++ b/Kwf/Assets/Package/TestPackage.php
@@ -29,7 +29,7 @@ class Kwf_Assets_Package_TestPackage extends Kwf_Assets_Package
             $providers[] = new Kwf_Assets_Provider_Ini('dependencies.ini');
         }
         $providers[] = new Kwf_Assets_Provider_IniNoFiles();
-        $providers[] = new Kwf_Assets_Provider_Components($rootComponentClass);
+        $providers[] = new Kwf_Assets_Components_Provider($rootComponentClass);
         $providers[] = new Kwf_Assets_Provider_Dynamic();
         $providers[] = new Kwf_Assets_TinyMce_Provider();
         $providers[] = new Kwf_Assets_Provider_AtRequires();

--- a/Kwf/Assets/ProviderList/Default.php
+++ b/Kwf/Assets/ProviderList/Default.php
@@ -5,7 +5,7 @@ class Kwf_Assets_ProviderList_Default extends Kwf_Assets_ProviderList_Abstract
     {
         $providers = array();
         if (Kwf_Component_Data_Root::getComponentClass()) {
-            $providers[] = new Kwf_Assets_Provider_Components(Kwf_Component_Data_Root::getComponentClass());
+            $providers[] = new Kwf_Assets_Components_Provider(Kwf_Component_Data_Root::getComponentClass());
         } else {
             $providers[] = new Kwf_Assets_Provider_NoComponents();
         }

--- a/Kwf/Assets/ProviderList/Test.php
+++ b/Kwf/Assets/ProviderList/Test.php
@@ -5,7 +5,7 @@ class Kwf_Assets_ProviderList_Test extends Kwf_Assets_ProviderList_Abstract
     {
         $providers = array();
         if (Kwf_Component_Data_Root::getComponentClass()) {
-            $providers[] = new Kwf_Assets_Provider_Components(Kwf_Component_Data_Root::getComponentClass());
+            $providers[] = new Kwf_Assets_Components_Provider(Kwf_Component_Data_Root::getComponentClass());
         }
         $providers[] = new Kwf_Assets_Provider_Ini(KWF_PATH.'/dependencies.ini');
         $providers[] = new Kwf_Assets_Provider_Ini($iniFile);

--- a/tests/Kwf/Assets/Components/ProviderTestDependencies.ini
+++ b/tests/Kwf/Assets/Components/ProviderTestDependencies.ini
@@ -1,0 +1,2 @@
+[dependencies]
+Frontend.dep[] = Components

--- a/tests/Kwf/Assets/Components/Root.php
+++ b/tests/Kwf/Assets/Components/Root.php
@@ -1,0 +1,17 @@
+<?php
+class Kwf_Assets_Components_Root extends Kwc_Abstract
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        $ret['generators']['page2'] = array(
+            'class' => 'Kwf_Component_Generator_Page_Static',
+            'component' => 'Kwf_Assets_Components_TestComponent2_Component',
+        );
+        $ret['generators']['page3'] = array(
+            'class' => 'Kwf_Component_Generator_Page_Static',
+            'component' => 'Kwf_Assets_Components_TestComponent3_Component',
+        );
+        return $ret;
+    }
+}

--- a/tests/Kwf/Assets/Components/Test.php
+++ b/tests/Kwf/Assets/Components/Test.php
@@ -1,0 +1,35 @@
+<?php
+class Kwf_Assets_Components_Test extends Kwc_TestAbstract
+{
+    private $_list;
+    public function setUp()
+    {
+        $this->_list = new Kwf_Assets_Components_TestProviderList();
+        parent::setUp('Kwf_Assets_Components_Root');
+    }
+
+    public function testPackageFiles()
+    {
+        $package = new Kwf_Assets_Package($this->_list, 'Frontend');
+
+        $it = new RecursiveIteratorIterator(new Kwf_Assets_Dependency_Iterator_Recursive($package->getDependency(), Kwf_Assets_Dependency_Abstract::DEPENDENCY_TYPE_ALL));
+        $array = iterator_to_array($it, false);
+        $this->assertEquals(2, count($array));
+    }
+
+    public function testFindDependency()
+    {
+        $this->assertNotNull($this->_list->findDependency('Frontend'));
+    }
+
+    public function testPackageContents()
+    {
+        $package = new Kwf_Assets_Package($this->_list, 'Frontend');
+
+        $contents = $package->getPackageContents('text/css', 'en', 0, false)->getFileContents();
+        $contents = trim($contents);
+        $contents = str_replace("\n\n", "\n", $contents);
+        $this->assertEquals(".kwfAssetsComponentsTestComponent2{testComponent:1}\n.kwfAssetsComponentsTestComponent2{testComponent:2}\n".
+                            ".kwfAssetsComponentsTestComponent3{testComponent:1}\n.kwfAssetsComponentsTestComponent3{testComponent:3}", $contents);
+    }
+}

--- a/tests/Kwf/Assets/Components/TestComponent1/Component.php
+++ b/tests/Kwf/Assets/Components/TestComponent1/Component.php
@@ -1,0 +1,9 @@
+<?php
+class Kwf_Assets_Components_TestComponent1_Component extends Kwc_Abstract
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        return $ret;
+    }
+}

--- a/tests/Kwf/Assets/Components/TestComponent1/Component.scss
+++ b/tests/Kwf/Assets/Components/TestComponent1/Component.scss
@@ -1,0 +1,3 @@
+.kwcClass {
+testComponent: 1
+}

--- a/tests/Kwf/Assets/Components/TestComponent2/Component.php
+++ b/tests/Kwf/Assets/Components/TestComponent2/Component.php
@@ -1,0 +1,9 @@
+<?php
+class Kwf_Assets_Components_TestComponent2_Component extends Kwf_Assets_Components_TestComponent1_Component
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        return $ret;
+    }
+}

--- a/tests/Kwf/Assets/Components/TestComponent2/Component.scss
+++ b/tests/Kwf/Assets/Components/TestComponent2/Component.scss
@@ -1,0 +1,3 @@
+.kwcClass {
+testComponent: 2
+}

--- a/tests/Kwf/Assets/Components/TestComponent3/Component.php
+++ b/tests/Kwf/Assets/Components/TestComponent3/Component.php
@@ -1,0 +1,9 @@
+<?php
+class Kwf_Assets_Components_TestComponent3_Component extends Kwf_Assets_Components_TestComponent1_Component
+{
+    public static function getSettings()
+    {
+        $ret = parent::getSettings();
+        return $ret;
+    }
+}

--- a/tests/Kwf/Assets/Components/TestComponent3/Component.scss
+++ b/tests/Kwf/Assets/Components/TestComponent3/Component.scss
@@ -1,0 +1,3 @@
+.kwcClass {
+testComponent: 3
+}

--- a/tests/Kwf/Assets/Components/TestProviderList.php
+++ b/tests/Kwf/Assets/Components/TestProviderList.php
@@ -1,12 +1,12 @@
 <?php
-class Kwf_Assets_ComponentsOverrideScss_TestProviderList extends Kwf_Assets_ProviderList_Abstract
+class Kwf_Assets_Components_TestProviderList extends Kwf_Assets_ProviderList_Abstract
 {
     public function __construct()
     {
         parent::__construct(array(
             new Kwf_Assets_Provider_Ini(dirname(__FILE__).'/ProviderTestDependencies.ini'),
             new Kwf_Assets_Provider_IniNoFiles(),
-            new Kwf_Assets_Components_Provider('Kwf_Assets_ComponentsOverrideScss_Root')
+            new Kwf_Assets_Components_Provider('Kwf_Assets_Components_Root')
         ));
     }
 }

--- a/tests/Kwf/Assets/Dependency/Test.php
+++ b/tests/Kwf/Assets/Dependency/Test.php
@@ -5,7 +5,7 @@ class Kwf_Assets_Dependency_Test extends Kwf_Test_TestCase
     {
         $f = new Kwf_Assets_Dependency_File_Js('kwf/Kwf_js/Kwf.js');
         $this->assertEquals('text/javascript', $f->getMimeType());
-        $this->assertContains('Kwf.log', $f->getContents('en'));
+        $this->assertContains('Kwf.clone', $f->getContents('en'));
         $this->assertEquals(array(), $f->getDependencies(Kwf_Assets_Dependency_Abstract::DEPENDENCY_TYPE_ALL));
     }
     public function testFileJsPacked()
@@ -14,7 +14,7 @@ class Kwf_Assets_Dependency_Test extends Kwf_Test_TestCase
         $this->assertEquals('text/javascript', $f->getMimeType());
         $c = $f->getContents('en');
         $cPacked = $f->getContentsPacked('en')->getFileContents();
-        $this->assertContains('Kwf.log', $cPacked);
+        $this->assertContains('Kwf.clone', $cPacked);
         $this->assertTrue(strlen($c) > strlen($cPacked));
     }
 
@@ -23,7 +23,7 @@ class Kwf_Assets_Dependency_Test extends Kwf_Test_TestCase
         $f = Kwf_Assets_Dependency_File::createDependency('kwf/Kwf_js/Kwf.js', new Kwf_Assets_Dependency_EmptyProviderList());
         $this->assertTrue($f instanceof Kwf_Assets_Dependency_File_Js);
         $this->assertEquals('text/javascript', $f->getMimeType());
-        $this->assertContains('Kwf.log', $f->getContents('en'));
+        $this->assertContains('Kwf.clone', $f->getContents('en'));
         $this->assertEquals(array(), $f->getDependencies(Kwf_Assets_Dependency_Abstract::DEPENDENCY_TYPE_ALL));
     }
 

--- a/tests/Kwf/Assets/DependencyWithComponents/TestProviderList.php
+++ b/tests/Kwf/Assets/DependencyWithComponents/TestProviderList.php
@@ -6,7 +6,7 @@ class Kwf_Assets_DependencyWithComponents_TestProviderList extends Kwf_Assets_Pr
         parent::__construct(array(
             new Kwf_Assets_Provider_Ini(dirname(__FILE__).'/ProviderTestDependencies.ini'),
             new Kwf_Assets_Provider_IniNoFiles(),
-            new Kwf_Assets_Provider_Components('Kwf_Assets_DependencyWithComponents_Root')
+            new Kwf_Assets_Components_Provider('Kwf_Assets_DependencyWithComponents_Root')
         ));
     }
 }


### PR DESCRIPTION
Instead of generating multiple classes in html duplicate the styles.


Example vwpkw5 css:

before:
rules: 1025
size: 152k
size zip: 18k

after:
rules: 1384    (+35%)
size: 177k     (+16%)
size zip: 19k  (+4%)
