### PR TITLE
Evaluate And/Or expressions correctly when used as condition

### DIFF
--- a/Kwf/Model/Db.php
+++ b/Kwf/Model/Db.php
@@ -479,13 +479,13 @@ class Kwf_Model_Db extends Kwf_Model_Abstract
             foreach ($expr->getExpressions() as $expression) {
                 $sqlExpressions[] = "(".$this->_createDbSelectExpression($expression, $dbSelect, $depOf, $tableNameAlias).")";
             }
-            return implode(" OR ", $sqlExpressions);
+            return '(' . implode(" OR ", $sqlExpressions) . ')';
         } else if ($expr instanceof Kwf_Model_Select_Expr_And) {
             $sqlExpressions = array();
             foreach ($expr->getExpressions() as $expression) {
                 $sqlExpressions[] = "(".$this->_createDbSelectExpression($expression, $dbSelect, $depOf, $tableNameAlias).")";
             }
-            return implode(" AND ", $sqlExpressions);
+            return '(' . implode(" AND ", $sqlExpressions) . ')';
         } else if ($expr instanceof Kwf_Model_Select_Expr_Add) {
             $sqlExpressions = array();
             foreach ($expr->getExpressions() as $expression) {

--- a/tests/Kwf/Model/Db/ExpressionTest.php
+++ b/tests/Kwf/Model/Db/ExpressionTest.php
@@ -148,7 +148,7 @@ class Kwf_Model_Db_ExpressionTest extends Kwf_Test_TestCase
 
         ));
         $select = $this->_model->select()->where($expr);
-        $this->assertEquals("SELECT \"testtable\".* FROM \"testtable\" WHERE ((testtable.foo = 'aaa') OR (testtable.foo = 'bbb'))",
+        $this->assertEquals("SELECT \"testtable\".* FROM \"testtable\" WHERE (((testtable.foo = 'aaa') OR (testtable.foo = 'bbb')))",
             $this->_model->createDbSelect($select)->__toString());
     }
 
@@ -160,7 +160,7 @@ class Kwf_Model_Db_ExpressionTest extends Kwf_Test_TestCase
 
         ));
         $select = $this->_model->select()->where($expr);
-        $this->assertEquals("SELECT \"testtable\".* FROM \"testtable\" WHERE ((testtable.foo = 'aaa') AND (testtable.foo = 'bbb'))",
+        $this->assertEquals("SELECT \"testtable\".* FROM \"testtable\" WHERE (((testtable.foo = 'aaa') AND (testtable.foo = 'bbb')))",
             $this->_model->createDbSelect($select)->__toString());
     }
 
@@ -196,8 +196,8 @@ class Kwf_Model_Db_ExpressionTest extends Kwf_Test_TestCase
         $expr4 = new Kwf_Model_Select_Expr_Or(array($expr, $expr2, $expr3));
 
         $select = $this->_model->select()->where($expr4);
-        $this->assertEquals("SELECT \"testtable\".* FROM \"testtable\" WHERE (((testtable.foo = 'aaa') AND ".
-         "(testtable.foo = 'bbb')) OR ((testtable.foo = 'aaa') OR (testtable.foo = 'bbb')) OR (NOT (testtable.foo = 'aaa')))",
+        $this->assertEquals("SELECT \"testtable\".* FROM \"testtable\" WHERE (((((testtable.foo = 'aaa') AND ".
+         "(testtable.foo = 'bbb'))) OR (((testtable.foo = 'aaa') OR (testtable.foo = 'bbb'))) OR (NOT (testtable.foo = 'aaa'))))",
             $this->_model->createDbSelect($select)->__toString());
 
     }

--- a/tests/Kwf/Model/DbWithConnection/ExprChildSum/BarModel.php
+++ b/tests/Kwf/Model/DbWithConnection/ExprChildSum/BarModel.php
@@ -31,6 +31,10 @@ class Kwf_Model_DbWithConnection_ExprChildSum_BarModel extends Kwf_Model_Db
     {
         parent::_init();
         $this->_exprs['foo_value_sum'] = new Kwf_Model_Select_Expr_Child_Sum('FooToBar', 'foo_value');
+        $this->_exprs['or_expr'] = new Kwf_Model_Select_Expr_Or(array(
+            new Kwf_Model_Select_Expr_Equal('bar', 4),
+            new Kwf_Model_Select_Expr_Equal('bar', 2)
+        ));
     }
 
     public function dropTable()

--- a/tests/Kwf/Model/DbWithConnection/ExprChildSum/Test.php
+++ b/tests/Kwf/Model/DbWithConnection/ExprChildSum/Test.php
@@ -73,4 +73,11 @@ class Kwf_Model_DbWithConnection_ExprChildSum_Test extends Kwf_Test_TestCase
         $sum = $row->foo_value_sum;
         $this->assertEquals(6, $sum);
     }
+
+    public function testOrExpression()
+    {
+        $select = new Kwf_Model_Select();
+        $select->whereEquals('or_expr', 0);
+        $this->assertEquals(1, $this->_modelBar->countRows($select));
+    }
 }


### PR DESCRIPTION
Current behaviour was "SELECT ... WHERE (a OR b = 0)", correct
behaviour is "SELECT ... WHERE (a OR b) = 0"