### PR TITLE
Change highlighting of searchresults and searchresults text itself

### DIFF
--- a/Kwc/FulltextSearch/Search/Detail/Component.tpl
+++ b/Kwc/FulltextSearch/Search/Detail/Component.tpl
@@ -2,5 +2,7 @@
     <a href="<?=$this->data->row->data->url?>">
         <?=$this->highlightTerms($this->queryParts, $this->data->row->data->name);?>
     </a>
-    <span class="preview"><?=$this->highlightTerms($this->queryParts, $this->data->row->content);?></span>
+    <span class="preview">
+        <?=$this->highlightTerms($this->queryParts, $this->data->row->content);?>
+    </span>
 </div>

--- a/Kwf/View/Helper/HighlightTerms.php
+++ b/Kwf/View/Helper/HighlightTerms.php
@@ -38,7 +38,7 @@ class Kwf_View_Helper_HighlightTerms
             // get from / to block positions
             $blocksPositions = array();
             foreach ($terms as $term) {
-                preg_match_all("/(^|\W)($term)(\W|$)/i", $text, $matches, PREG_OFFSET_CAPTURE);
+                preg_match_all("/(^|\W)($term)/i", $text, $matches, PREG_OFFSET_CAPTURE);
                 $m = $matches[2];
                 $blocks = count($m) > $options['maxReturnBlocks'] ? $options['maxReturnBlocks'] : count($m);
                 if ($blocks >= 1) {
@@ -148,13 +148,12 @@ class Kwf_View_Helper_HighlightTerms
         $c = 1;
         foreach ($terms as $term) {
             $ret = preg_replace(
-                "/(^|\W)($term)(\W|$)/i",
+                '/(^|\W)('.$term.')/i',
                 '$1<span class="highlightTerms highlightTerm'.$c.'">$2</span>$3',
                 $ret
             );
             $c++;
         }
-
         return $ret;
     }
 }

--- a/tests/Kwf/View/HighlightTermsTest.php
+++ b/tests/Kwf/View/HighlightTermsTest.php
@@ -26,12 +26,12 @@ class Kwf_View_HighlightTermsTest extends Kwf_Test_TestCase
         $res = $h->highlightTerms($searchWord, $this->_text, array('maxReturnLength' => 0));
 
         $highlights = mb_substr_count($res, '<span ');
-        $this->assertEquals(7, $highlights);
+        $this->assertEquals(8, $highlights);
 
         $this->assertRegExp('/<span class="highlightTerms highlightTerm1">für<\/span>/', $res);
         $this->assertRegExp('/<span class="highlightTerms highlightTerm1">Für<\/span>/', $res);
         $this->assertNotRegExp('/hier<span class="highlightTerms highlightTerm1">für<\/span>/', $res);
-        $this->assertNotRegExp('/<span class="highlightTerms highlightTerm1">Für<\/span>wahr/', $res);
+        $this->assertRegExp('/<span class="highlightTerms highlightTerm1">Für<\/span>wahr/', $res);
 
         $res = $h->highlightTerms(array('Highlighten', ' '), $this->_text, array('maxReturnLength' => 0));
         $highlights = mb_substr_count($res, '<span ');
@@ -99,5 +99,21 @@ Im neuen Golf GTI können Sie sich die Freiheit nehmen, die Sie brauchen - egal,
 
         $this->assertEquals(50, mb_strlen($res));
         $this->assertEquals('Für. Dies ist ein Text für das Highlighten des Tex', $res);
+    }
+
+    public function testSearchwordInResult()
+    {
+        $searchWords = 'bau';
+        $text = 'Das Suchwort wird erst zum Schluss vorkommen. Dann können wir '
+                .'überprüfen, ob die Funktion nur einen Textteil vom Anfang ausgibt '
+                .'oder ob er richtigerweise einen Textteil ausgibt wo auch das '
+                .'Suchwort vorkommt. Das ist wichtig, damit man bei jedem Suchergebnis '
+                .'auch zumindest ein gehighlightetes Wort findet. Sonst weiß '
+                .'der Besucher nicht warum das Ergebnis überhaupt angezeigt wird'
+                .'Sodala, und jetzt endlich das Suchwort ganz am Ende drann, Baustelle';
+        $h = new Kwf_View_Helper_HighlightTerms();
+        $res = $h->highlightTerms($searchWords, $text);
+        $this->assertContains('bau', $res, '', true);
+        $this->assertContains('<span class="highlightTerms highlightTerm1">Bau</span>', $res);
     }
 }


### PR DESCRIPTION
Change highlightingTerms function to always get resulttext with the searchterms in it.
Change highlighting to hihglight all partials of the searchterms, not only the exact alone standing word.
This behavior can be changed with the "highlightWordPartial" option.
    
Add a Test to check if the resulttext has the searchterms in it.
