### PR TITLE
Add image dimensions to uploads table

### DIFF
--- a/Kwc/Abstract/Image/Component.php
+++ b/Kwc/Abstract/Image/Component.php
@@ -112,7 +112,7 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
 
         $imageData = $this->getImageDataOrEmptyImageData();
         $ret = array_merge($ret,
-            Kwf_Media_Output_Component::getResponsiveImageVars($this->getImageDimensions(), $imageData['file'])
+            Kwf_Media_Output_Component::getResponsiveImageVars($this->getImageDimensions(), $imageData['dimensions'])
         );
 
         $ret['baseUrl'] = $this->getBaseImageUrl();
@@ -193,7 +193,7 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
             $s = $this->getImageDimensions();
             $imageData = $this->_getImageDataOrEmptyImageData();
             $width = Kwf_Media_Image::getResponsiveWidthStep($s['width'],
-                                Kwf_Media_Image::getResponsiveWidthSteps($s, $imageData['file']));
+                                Kwf_Media_Image::getResponsiveWidthSteps($s, $imageData['dimensions']));
             if (Kwc_Abstract::getSetting($this->getData()->componentClass, 'useDataUrl')) {
                 $id = $this->getData()->componentId;
                 $type = str_replace('{width}', $width, $this->getBaseType());
@@ -255,6 +255,7 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
             'file' => $file,
             'mimeType' => $fileRow->mime_type,
             'row' => $row,
+            'dimensions' => $fileRow->getImageDimensions(),
             'uploadId' => $fileRow->id
         );
     }
@@ -347,7 +348,9 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
             $size['width'] = $this->getContentWidth();
         }
         $data = $this->_getImageDataOrEmptyImageData();
-        if (isset($data['image'])) {
+        if (isset($data['dimensions'])) {
+            $size = Kwf_Media_Image::calculateScaleDimensions($data['dimensions'], $size);
+        } else if (isset($data['image'])) {
             $size = Kwf_Media_Image::calculateScaleDimensions($data['image'], $size);
         } else {
             $size = Kwf_Media_Image::calculateScaleDimensions($data['file'], $size);

--- a/Kwc/Basic/Image/Component.php
+++ b/Kwc/Basic/Image/Component.php
@@ -29,7 +29,12 @@ class Kwc_Basic_Image_Component extends Kwc_Abstract_Image_Component
         return array(
             'filename' => $emptyImage,
             'file' => $file,
-            'mimeType' => $s['mime']
+            'mimeType' => $s['mime'],
+            'dimensions' => array(
+                'width' => $s[0],
+                'height' => $s[1],
+                'rotation' => 0,
+            )
         );
     }
 }

--- a/Kwf/Controller/Action/Cli/Web/UpdateUploadsController.php
+++ b/Kwf/Controller/Action/Cli/Web/UpdateUploadsController.php
@@ -1,5 +1,5 @@
 <?php
-class Kwf_Controller_Action_Cli_Web_UpdateTo39Controller extends Kwf_Controller_Action_Cli_Abstract
+class Kwf_Controller_Action_Cli_Web_UpdateUploadsController extends Kwf_Controller_Action_Cli_Abstract
 {
     private $_progressBar;
 
@@ -36,5 +36,21 @@ class Kwf_Controller_Action_Cli_Web_UpdateTo39Controller extends Kwf_Controller_
     public function moveOldFilesAction()
     {
         $this->_getUpdate()->moveOldFiles();
+    }
+
+    public function calculateDimensionsAction()
+    {
+        $update = new Kwf_Update_20151012UploadsDimensions('Kwf_Update_20151012UploadsDimensions');
+        $c = new Zend_ProgressBar_Adapter_Console();
+        $c->setElements(array(
+            Zend_ProgressBar_Adapter_Console::ELEMENT_PERCENT,
+            Zend_ProgressBar_Adapter_Console::ELEMENT_BAR,
+            Zend_ProgressBar_Adapter_Console::ELEMENT_TEXT
+        ));
+        $c->setTextWidth(50);
+        $progress = new Zend_ProgressBar($c, 0, $update->countUploads());
+        $update->setProgressBar($progress);
+        $update->calculateDimensions();
+        exit;
     }
 }

--- a/Kwf/Media/Output/Component.php
+++ b/Kwf/Media/Output/Component.php
@@ -92,7 +92,7 @@ class Kwf_Media_Output_Component
             $baseType = $c->getComponent()->getBaseType();
             $dim = $c->getComponent()->getImageDimensions();
             $imageData = $c->getComponent()->getImageDataOrEmptyImageData();
-            $widths = Kwf_Media_Image::getResponsiveWidthSteps($dim, isset($imageData['image']) ? $imageData['image'] : $imageData['file']);
+            $widths = Kwf_Media_Image::getResponsiveWidthSteps($dim, $imageData['dimensions']);
             $ok = false;
             foreach ($widths as $w) {
                 if (str_replace('{width}', $w, $baseType) == $type) {

--- a/Kwf/Update/20150309Legacy39000.php
+++ b/Kwf/Update/20150309Legacy39000.php
@@ -141,7 +141,7 @@ class Kwf_Update_20150309Legacy39000 extends Kwf_Update
             $this->createHashes();
             $this->moveOldFiles();
         } else {
-            echo "More than 5000 Uploads. Please execute renaming manually:\n\"php bootstrap.php update-to39 rename-uploads\"\n\"php bootstrap.php update-to39 create-hashes\"\n\"php bootstrap.php update-to39 move-old-files\"\n";
+            echo "More than 5000 Uploads. Please execute renaming manually:\n\"php bootstrap.php update-uploads rename-uploads\"\n\"php bootstrap.php update-uploads create-hashes\"\n\"php bootstrap.php update-uploads move-old-files\"\n";
         }
     }
 

--- a/Kwf/Update/20151012UploadsDimensions.php
+++ b/Kwf/Update/20151012UploadsDimensions.php
@@ -1,0 +1,64 @@
+<?php
+class Kwf_Update_20151012UploadsDimensions extends Kwf_Update
+{
+    private $_countUploads;
+
+    public function getProgressSteps()
+    {
+        $ret = count(Kwf_Model_Abstract::findAllInstances());
+        if ($this->countUploads() < 5000) {
+            $ret += $this->countUploads();
+        }
+        return $ret;
+    }
+
+    public function countUploads()
+    {
+        if (is_null($this->_countUploads)) {
+            if (in_array('kwf_uploads', Kwf_Registry::get('db')->listTables())) {
+                $this->_countUploads = Kwf_Registry::get('db')->query('SELECT COUNT(*) FROM kwf_uploads')->fetchColumn();
+            } else {
+                $this->_countUploads = 0;
+            }
+        }
+        return $this->_countUploads;
+    }
+
+    public function update()
+    {
+        $db = Kwf_Registry::get('db');
+
+        $db->query("ALTER TABLE  `kwf_uploads` ADD  `is_image` TINYINT NOT NULL;");
+        $db->query("UPDATE `kwf_uploads` SET `is_image`=-1;"); //-1 means unknown
+        $db->query("ALTER TABLE  `kwf_uploads` ADD  `image_width` INT NULL;");
+        $db->query("ALTER TABLE  `kwf_uploads` ADD  `image_height` INT NULL;");
+        $db->query("ALTER TABLE  `kwf_uploads` ADD  `image_rotation` INT NULL;");
+
+        if ($this->countUploads() < 5000) {
+            $this->calculateDimensions();
+        } else {
+            echo "More than 5000 Uploads. Please execute renaming manually:\n\"php bootstrap.php update-uploads calculate-dimensions\"\n";
+        }
+    }
+
+    public function calculateDimensions()
+    {
+        $db = Kwf_Registry::get('db');
+        $s = new Kwf_Model_Select();
+        $it = new Kwf_Model_Iterator_Packages(
+            new Kwf_Model_Iterator_Rows(Kwf_Model_Abstract::getInstance('Kwf_Uploads_Model'), $s)
+        );
+        foreach ($it as $row) {
+            $this->_progressBar->next(1, 'calculating dimension '.$row->id);
+            if (file_exists($row->getFileSource())) {
+                $size = getimagesize($row->getFileSource());
+                if ($size) {
+                    $width = $size[0];
+                    $height = $size[1];
+                    $rotation = Kwf_Media_Image::getExifRotation($row->getFileSource());
+                    $db->query("UPDATE `kwf_uploads` SET  `is_image`=1, `image_width` =  '{$width}', `image_height` =  '{$height}', `image_rotation` =  '{$rotation}' WHERE  `id` = '{$row->id}';");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
With that we don't have to touch the upload files during view rendering at all. That improves performance if the uploads are on a slow filesystem (NFS)