### PR TITLE
Set copy of baseParams not same object.

### DIFF
--- a/Kwc/Paragraphs/Panel.js
+++ b/Kwc/Paragraphs/Panel.js
@@ -258,6 +258,7 @@ Kwc.Paragraphs.Panel = Ext2.extend(Kwf.Binding.AbstractPanel,
         }
     },
     setBaseParams : function(baseParams) {
+        baseParams = Kwf.clone(baseParams);
         if (this.getStore()) {
             this.getStore().baseParams = baseParams;
         } else {


### PR DESCRIPTION
Else store adds meta=undefined resulting in missing meta param for
first request.