### PR TITLE
Add additional config-setting to simplify solr configuration

### DIFF
--- a/Kwf/Util/Fulltext/Backend/Solr.php
+++ b/Kwf/Util/Fulltext/Backend/Solr.php
@@ -23,9 +23,11 @@ class Kwf_Util_Fulltext_Backend_Solr extends Kwf_Util_Fulltext_Backend_Abstract
 
         if (!isset($i[$subrootId])) {
             $solr = Kwf_Config::getValueArray('fulltext.solr');
+            $basePath = $solr['basePath'];
             $path = $solr['path'];
             $subrootPart = $subrootId;
             if (!$subrootPart) $subrootPart = 'root';
+            $path = str_replace('%basePath%', $basePath, $path);
             $path = str_replace('%subroot%', $subrootPart, $path);
             $path = str_replace('%appid%', Kwf_Config::getValue('application.id'), $path);
             $i[$subrootId] = new Kwf_Util_Fulltext_Solr_Service($solr['host'], $solr['port'], $path);

--- a/config.ini
+++ b/config.ini
@@ -106,7 +106,8 @@ fulltext.backend = Kwf_Util_Fulltext_Backend_ZendSearch
 fulltext.solr.startServerPath = false
 fulltext.solr.host = localhost
 fulltext.solr.port = 8180
-fulltext.solr.path = /%appid%/%subroot%/
+fulltext.solr.basePath = /%appid%
+fulltext.solr.path = /%basePath%/%subroot%/
 
 processControl.maintenanceJobs.cmd = maintenance-jobs run
 
@@ -221,5 +222,5 @@ whileUpdatingShowMaintenancePage = false
 paypalDomain = www.sandbox.paypal.com
 server.mongo.database = %id%_test
 server.gearman.functionPrefix = test
-fulltext.solr.path = /test.%appid%/%subroot%/
+fulltext.solr.basePath = /test.%appid%
 clearCacheSkipProcessControl = true


### PR DESCRIPTION
solr on production and test is always configured differently per web
this way config-setting for local development doesn't need to be
reset to default in every web.