### PR TITLE
Only call _attachEditableToMenuData for submenu if submenu set

### DIFF
--- a/Kwc/Menu/Expanded/ParentMenu/Trl/Component.php
+++ b/Kwc/Menu/Expanded/ParentMenu/Trl/Component.php
@@ -5,6 +5,7 @@ class Kwc_Menu_Expanded_ParentMenu_Trl_Component extends Kwc_Menu_ParentMenu_Trl
     {
         $ret = parent::getTemplateVars($renderer);
         foreach ($ret['menu'] as $k=>$m) {
+            $ret['menu'][$k]['submenu'] = array();
             $masterSubMenu = $this->getData()->chained->getComponent()->getMenuData($m['data']->chained, array('ignoreVisible'=>true), 'Kwc_Menu_Expanded_EditableItems_Component');
             foreach ($masterSubMenu as $sm) {
                 $sComponent = Kwc_Chained_Trl_Component::getChainedByMaster($sm['data'], $this->getData());


### PR DESCRIPTION
Else code in Kwc_Menu_Expanded_EditableItems_Trl_Component crashes
if no subpages visible. According to Kwc_Menu_Expanded_ParentMenu_Component
isset should be checked.