### PR TITLE
Dont do trlStaticExecute in getForm()

### DIFF
--- a/Kwc/Form/Component.php
+++ b/Kwc/Form/Component.php
@@ -7,6 +7,7 @@ class Kwc_Form_Component extends Kwc_Abstract_Composite_Component
     private $_initialized = false;
     private $_posted = false;
     private $_postData = array();
+    private $_formTrlStaticExecuted = false;
     protected $_errors = array();
 
     public static function getSettings()
@@ -112,6 +113,10 @@ class Kwc_Form_Component extends Kwc_Abstract_Composite_Component
         }
 
         if (!$this->getForm()) return;
+
+        $this->getForm()->trlStaticExecute($this->getData()->getLanguage());
+        $this->_formTrlStaticExecuted = true;
+
 
         if ($this->_getIdFromPostData($postData)) {
             $this->getForm()->setId($this->_getIdFromPostData($postData));
@@ -245,8 +250,6 @@ class Kwc_Form_Component extends Kwc_Abstract_Composite_Component
             $this->_initForm();
 
             $this->_form->initFields();
-
-            if ($this->_form) $this->_form->trlStaticExecute($this->getData()->getLanguage());
         }
         return $this->_form;
     }
@@ -261,6 +264,11 @@ class Kwc_Form_Component extends Kwc_Abstract_Composite_Component
         $ret = Kwc_Abstract::getTemplateVars($renderer);
 
         $this->_checkWasProcessed();
+
+        if (!$this->_formTrlStaticExecuted) {
+            $this->getForm()->trlStaticExecute($this->getData()->getLanguage());
+            $this->_formTrlStaticExecuted = true;
+        }
 
         $ret['isPosted'] = $this->_posted;
         $ret['showSuccess'] = false;

--- a/Kwc/Shop/AddToCartAbstract/Trl/Form/Component.php
+++ b/Kwc/Shop/AddToCartAbstract/Trl/Form/Component.php
@@ -11,8 +11,6 @@ class Kwc_Shop_AddToCartAbstract_Trl_Form_Component extends Kwc_Form_Component
     protected function _initForm()
     {
         $this->_form = $this->getData()->parent->chained->getComponent()->getForm();
-
-        parent::_initForm();
     }
 
     protected function _beforeInsert(Kwf_Model_Row_Interface $row)


### PR DESCRIPTION
This results in problems with trl component getting already translated
form not able to retranslate. Now this is done in processInput and
getTemplateVars because data is correct.