### PR TITLE
Columns: don't use parentComponentClass, instead hardcode Paragraphs

### DIFF
--- a/Kwc/Columns/Abstract/Component.php
+++ b/Kwc/Columns/Abstract/Component.php
@@ -1,8 +1,7 @@
 <?php
 class Kwc_Columns_Abstract_Component extends Kwc_Abstract_List_Component
 {
-    public static $needsParentComponentClass = true;
-    public static function getSettings($parentComponentClass)
+    public static function getSettings()
     {
         $ret = parent::getSettings();
         $ret['componentName'] = trlKwfStatic('Columns');
@@ -13,7 +12,7 @@ class Kwc_Columns_Abstract_Component extends Kwc_Abstract_List_Component
 
         $ret['generators']['child'] = array(
             'class' => 'Kwc_Columns_Abstract_Generator',
-            'component' => $parentComponentClass
+            'component' => 'Kwc_Paragraphs_Component'
         );
         $ret['extConfig'] = 'Kwc_Columns_Abstract_ExtConfig';
         $ret['assetsAdmin']['files'][] = 'kwf/Kwc/Columns/Abstract/List.js';


### PR DESCRIPTION
- This improves performance as less different classes exist statically
- Fixes problems if the outer paragraphs does custom stuff we don't want in a column again