### PR TITLE
Add getHtml function to auth-interface to enable saml2 login-post

### DIFF
--- a/Kwc/User/Login/Component.php
+++ b/Kwc/User/Login/Component.php
@@ -47,8 +47,13 @@ class Kwc_User_Login_Component extends Kwc_Abstract_Composite_Component
             $ns->state = $state;
 
             $url = $auth->getLoginRedirectUrl($this->_getRedirectBackUrl(), $state, $formValues);
-            header("Location: ".$url);
-            exit;
+            if ($url) {
+                header("Location: ".$url);
+                exit;
+            } else {
+                echo $auth->getLoginRedirectHtml($this->_getRedirectBackUrl(), $state, $formValues);
+                exit;
+            }
         }
         if ($postData != array() && array_keys($postData) != array('redirect')) {
             $user = null;

--- a/Kwf/User/Auth/Interface/Redirect.php
+++ b/Kwf/User/Auth/Interface/Redirect.php
@@ -53,6 +53,15 @@ interface Kwf_User_Auth_Interface_Redirect
     public function getLoginRedirectUrl($redirectBackUrl, $state, $formValues);
 
     /**
+     * Returns html code to be output to do a redirect when using this auth method
+     *
+     * @param $redirectBackUrl
+     * @param $state
+     * @param $formValues
+     */
+    public function getLoginRedirectHtml($redirectBackUrl, $state, $formValues);
+
+    /**
      * Returns the (existing) user that should be logged in by $params. The User must be already associated
      * to this sso account.
      *

--- a/Kwf/User/Auth/Proxy/Redirect.php
+++ b/Kwf/User/Auth/Proxy/Redirect.php
@@ -26,6 +26,11 @@ class Kwf_User_Auth_Proxy_Redirect extends Kwf_User_Auth_Proxy_Abstract implemen
         return $this->_auth->getLoginRedirectUrl($redirectBackUrl, $state, $formValues);
     }
 
+    public function getLoginRedirectHtml($redirectBackUrl, $state, $formValues)
+    {
+        return $this->_auth->getLoginRedirectHtml($redirectBackUrl, $state, $formValues);
+    }
+
     public function getUserToLoginByParams(array $params)
     {
         $row = $this->_auth->getUserToLoginByParams($params);

--- a/Kwf/User/Auth/Union/Redirect.php
+++ b/Kwf/User/Auth/Union/Redirect.php
@@ -26,6 +26,11 @@ class Kwf_User_Auth_Union_Redirect extends Kwf_User_Auth_Union_Abstract implemen
         return $this->_auth->getLoginRedirectUrl($redirectBackUrl, $state, $formValues);
     }
 
+    public function getLoginRedirectHtml($redirectBackUrl, $state, $formValues)
+    {
+        return $this->_auth->getLoginRedirectHtml($redirectBackUrl, $state, $formValues);
+    }
+
     public function getUserToLoginByParams(array $params)
     {
         $row = $this->_auth->getUserToLoginByParams($params);


### PR DESCRIPTION
Saml2 needs to do a post to a defined url containing SAMLRequest
data. This isn't possible with GET of an url. Now it's possible
to define html to be output to do so. GetUrl should return false
to indicate html is needed.