### PR TITLE
Remove code to detect mimetype

### DIFF
--- a/Kwf/Uploads/Row.php
+++ b/Kwf/Uploads/Row.php
@@ -71,31 +71,6 @@ class Kwf_Uploads_Row extends Kwf_Model_Proxy_Row
     public static function detectMimeType($mimeType, $contents)
     {
         $ret = $mimeType;
-        if (!$mimeType || $mimeType == 'application/octet-stream') {
-            if (function_exists('finfo_open')) {
-                //für andere server muss dieser pfad vielleicht einstellbar gemacht werden
-                $path = false;
-                if (is_file('/usr/share/file/magic')) {
-                    $path = '/usr/share/file/magic';
-                } else if (is_file('/usr/share/misc/magic')) {
-                    $path = '/usr/share/misc/magic';
-                } else {
-                    $path = null;
-                }
-                $finfo = new finfo(FILEINFO_MIME, $path);
-                $ret = $finfo->buffer($contents);
-                $ret = str_replace('; charset=binary', '', $ret);
-                if($ret == 'application/zip') {
-                    $path = Kwf_Config::getValue('externLibraryPath.file');
-                    $finfo = new finfo(FILEINFO_MIME, $path);
-                    $ret = $finfo->buffer($contents);
-                    $ret = str_replace('; charset=binary', '', $ret);
-                }
-            } else {
-                throw new Kwf_Exception("Can't autodetect mimetype, install FileInfo extension");
-            }
-        }
-
         if (!$ret) {
             $ret = 'application/octet-stream';
         }


### PR DESCRIPTION
This code uses static files which does not work with sles11. All
currently supported browsers do correctly set mimetype and therefore
this code isn't needed anymore.