### PR TITLE
Update dependencies, don't define exact versions for npm and bower dependencies

### DIFF
--- a/composer-extra-assets.lock
+++ b/composer-extra-assets.lock
@@ -1,0 +1,1315 @@
+{
+    "bower-dependencies": {
+        "compass-mixins": "git://github.com/koala-framework/compass-mixins.git#7319116335",
+        "jquery": "git://github.com/jquery/jquery.git#2.1.4",
+        "matches-selector": "git://github.com/desandro/matches-selector.git#1.0.3",
+        "qunit-phantomjs-runner": "git://github.com/vivid-planet/qunit-phantomjs-runner.git#e96347ee33",
+        "qunit": "git://github.com/jquery/qunit.git#1.20.0",
+        "tinymce": "git://github.com/tinymce/tinymce.git#4.1.9",
+        "underscore": "git://github.com/jashkenas/underscore.git#1.8.3"
+    },
+    "npm-dependencies": {
+        "koala-framework/kwf-trl-jsparser": {
+            "esprima": {
+                "version": "1.2.2",
+                "from": "esprima@1.2.2",
+                "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+            }
+        },
+        "self": {
+            "abbrev": {
+                "version": "1.0.7",
+                "from": "abbrev@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            },
+            "acorn": {
+                "version": "1.2.2",
+                "from": "acorn@>=1.0.3 <2.0.0",
+                "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+            },
+            "align-text": {
+                "version": "0.1.3",
+                "from": "align-text@>=0.1.0 <0.2.0",
+                "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz"
+            },
+            "amdefine": {
+                "version": "1.0.0",
+                "from": "amdefine@>=0.0.4",
+                "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            },
+            "amdlc": {
+                "version": "0.1.6",
+                "from": "amdlc@0.1.6",
+                "resolved": "https://registry.npmjs.org/amdlc/-/amdlc-0.1.6.tgz"
+            },
+            "ansi": {
+                "version": "0.3.0",
+                "from": "ansi@>=0.3.0 <0.4.0",
+                "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+            },
+            "ansi-regex": {
+                "version": "2.0.0",
+                "from": "ansi-regex@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+            },
+            "ansi-styles": {
+                "version": "2.1.0",
+                "from": "ansi-styles@>=2.1.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "are-we-there-yet": {
+                "version": "1.0.5",
+                "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+            },
+            "array-index": {
+                "version": "0.1.1",
+                "from": "array-index@>=0.1.0 <0.2.0",
+                "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz"
+            },
+            "asn1": {
+                "version": "0.2.3",
+                "from": "asn1@>=0.2.3 <0.3.0",
+                "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+            },
+            "assert-plus": {
+                "version": "0.1.5",
+                "from": "assert-plus@>=0.1.5 <0.2.0",
+                "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "async": {
+                "version": "0.2.10",
+                "from": "async@>=0.2.6 <0.3.0"
+            },
+            "async-foreach": {
+                "version": "0.1.3",
+                "from": "async-foreach@>=0.1.3 <0.2.0",
+                "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+            },
+            "aws-sign2": {
+                "version": "0.6.0",
+                "from": "aws-sign2@>=0.6.0 <0.7.0",
+                "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "balanced-match": {
+                "version": "0.3.0",
+                "from": "balanced-match@>=0.3.0 <0.4.0",
+                "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+            },
+            "bl": {
+                "version": "1.0.0",
+                "from": "bl@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                "dependencies": {
+                    "readable-stream": {
+                        "version": "2.0.4",
+                        "from": "readable-stream@>=2.0.0 <2.1.0",
+                        "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
+                    }
+                }
+            },
+            "block-stream": {
+                "version": "0.0.8",
+                "from": "block-stream@*",
+                "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+            },
+            "boom": {
+                "version": "2.10.1",
+                "from": "boom@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+            },
+            "brace-expansion": {
+                "version": "1.1.2",
+                "from": "brace-expansion@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz"
+            },
+            "browser-pack": {
+                "version": "5.0.1",
+                "from": "browser-pack@5.0.1",
+                "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz"
+            },
+            "browser-resolve": {
+                "version": "1.11.0",
+                "from": "browser-resolve@>=1.7.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.0.tgz"
+            },
+            "builtin-modules": {
+                "version": "1.1.0",
+                "from": "builtin-modules@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+            },
+            "camelcase": {
+                "version": "2.0.1",
+                "from": "camelcase@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+            },
+            "camelcase-keys": {
+                "version": "2.0.0",
+                "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz"
+            },
+            "caseless": {
+                "version": "0.11.0",
+                "from": "caseless@>=0.11.0 <0.12.0",
+                "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "center-align": {
+                "version": "0.1.2",
+                "from": "center-align@>=0.1.1 <0.2.0",
+                "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
+            },
+            "chalk": {
+                "version": "1.1.1",
+                "from": "chalk@>=1.1.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+            },
+            "cliui": {
+                "version": "3.1.0",
+                "from": "cliui@>=3.0.3 <4.0.0",
+                "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz"
+            },
+            "code-point-at": {
+                "version": "1.0.0",
+                "from": "code-point-at@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+            },
+            "combine-source-map": {
+                "version": "0.6.1",
+                "from": "combine-source-map@>=0.6.1 <0.7.0",
+                "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+                "dependencies": {
+                    "source-map": {
+                        "version": "0.4.4",
+                        "from": "source-map@>=0.4.2 <0.5.0",
+                        "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+                    }
+                }
+            },
+            "combined-stream": {
+                "version": "1.0.5",
+                "from": "combined-stream@>=1.0.5 <1.1.0",
+                "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+            },
+            "commander": {
+                "version": "2.9.0",
+                "from": "commander@>=2.9.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+            },
+            "concat-map": {
+                "version": "0.0.1",
+                "from": "concat-map@0.0.1",
+                "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            },
+            "concat-stream": {
+                "version": "1.4.10",
+                "from": "concat-stream@>=1.4.5 <1.5.0",
+                "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
+            },
+            "config-chain": {
+                "version": "1.1.9",
+                "from": "config-chain@>=1.1.8 <1.2.0",
+                "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz"
+            },
+            "convert-source-map": {
+                "version": "1.1.2",
+                "from": "convert-source-map@>=1.1.0 <1.2.0",
+                "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+            },
+            "core-util-is": {
+                "version": "1.0.2",
+                "from": "core-util-is@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "cross-spawn": {
+                "version": "2.1.0",
+                "from": "cross-spawn@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.1.0.tgz"
+            },
+            "cross-spawn-async": {
+                "version": "2.0.1",
+                "from": "cross-spawn-async@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.0.1.tgz"
+            },
+            "cryptiles": {
+                "version": "2.0.5",
+                "from": "cryptiles@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+            },
+            "dashdash": {
+                "version": "1.10.1",
+                "from": "dashdash@>=1.10.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
+            },
+            "debug": {
+                "version": "2.2.0",
+                "from": "debug@*",
+                "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+            },
+            "decamelize": {
+                "version": "1.1.1",
+                "from": "decamelize@>=1.1.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+            },
+            "defined": {
+                "version": "1.0.0",
+                "from": "defined@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
+            "delayed-stream": {
+                "version": "1.0.0",
+                "from": "delayed-stream@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+            },
+            "delegates": {
+                "version": "0.1.0",
+                "from": "delegates@>=0.1.0 <0.2.0",
+                "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+            },
+            "detective": {
+                "version": "4.3.1",
+                "from": "detective@>=4.0.0 <5.0.0",
+                "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
+            },
+            "doctrine": {
+                "version": "0.6.4",
+                "from": "doctrine@>=0.6.4 <0.7.0",
+                "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz"
+            },
+            "duplexer2": {
+                "version": "0.0.2",
+                "from": "duplexer2@0.0.2",
+                "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+            },
+            "ecc-jsbn": {
+                "version": "0.1.1",
+                "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+            },
+            "error-ex": {
+                "version": "1.3.0",
+                "from": "error-ex@>=1.2.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+            },
+            "escape-string-regexp": {
+                "version": "1.0.3",
+                "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "esprima": {
+                "version": "1.2.5",
+                "from": "esprima@1.2.5",
+                "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "esutils": {
+                "version": "1.1.6",
+                "from": "esutils@>=1.1.6 <2.0.0",
+                "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "extend": {
+                "version": "3.0.0",
+                "from": "extend@>=3.0.0 <3.1.0",
+                "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "extsprintf": {
+                "version": "1.0.2",
+                "from": "extsprintf@1.0.2",
+                "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+            },
+            "file": {
+                "version": "0.2.2",
+                "from": "file@>=0.2.2 <0.3.0",
+                "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz"
+            },
+            "find-parent-dir": {
+                "version": "0.3.0",
+                "from": "find-parent-dir@>=0.3.0 <0.4.0",
+                "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
+            },
+            "find-up": {
+                "version": "1.1.0",
+                "from": "find-up@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz"
+            },
+            "forever-agent": {
+                "version": "0.6.1",
+                "from": "forever-agent@>=0.6.1 <0.7.0",
+                "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+                "version": "1.0.0-rc3",
+                "from": "form-data@>=1.0.0-rc3 <1.1.0",
+                "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                "dependencies": {
+                    "async": {
+                        "version": "1.5.0",
+                        "from": "async@>=1.4.0 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                    }
+                }
+            },
+            "fstream": {
+                "version": "1.0.8",
+                "from": "fstream@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                "dependencies": {
+                    "graceful-fs": {
+                        "version": "4.1.2",
+                        "from": "graceful-fs@>=4.1.2 <5.0.0",
+                        "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    }
+                }
+            },
+            "gauge": {
+                "version": "1.2.2",
+                "from": "gauge@>=1.2.0 <1.3.0",
+                "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+            },
+            "gaze": {
+                "version": "0.5.2",
+                "from": "gaze@>=0.5.1 <0.6.0",
+                "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+            },
+            "generate-function": {
+                "version": "2.0.0",
+                "from": "generate-function@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+            },
+            "generate-object-property": {
+                "version": "1.2.0",
+                "from": "generate-object-property@>=1.1.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+            },
+            "get-stdin": {
+                "version": "4.0.1",
+                "from": "get-stdin@>=4.0.1 <5.0.0",
+                "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "glob": {
+                "version": "6.0.1",
+                "from": "glob@>=3.1.12",
+                "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.1.tgz"
+            },
+            "globule": {
+                "version": "0.1.0",
+                "from": "globule@>=0.1.0 <0.2.0",
+                "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                "dependencies": {
+                    "glob": {
+                        "version": "3.1.21",
+                        "from": "glob@>=3.1.21 <3.2.0"
+                    },
+                    "inherits": {
+                        "version": "1.0.2",
+                        "from": "inherits@>=1.0.0 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                    },
+                    "lodash": {
+                        "version": "1.0.2",
+                        "from": "lodash@>=1.0.1 <1.1.0",
+                        "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                    },
+                    "lru-cache": {
+                        "version": "2.7.3",
+                        "from": "lru-cache@>=2.0.0 <3.0.0",
+                        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "minimatch": {
+                        "version": "0.2.14",
+                        "from": "minimatch@>=0.2.11 <0.3.0"
+                    }
+                }
+            },
+            "graceful-fs": {
+                "version": "1.2.3",
+                "from": "graceful-fs@>=1.2.0 <1.3.0",
+                "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "graceful-readlink": {
+                "version": "1.0.1",
+                "from": "graceful-readlink@>=1.0.0",
+                "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            },
+            "har-validator": {
+                "version": "2.0.3",
+                "from": "har-validator@>=2.0.2 <2.1.0",
+                "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+            },
+            "has-ansi": {
+                "version": "2.0.0",
+                "from": "has-ansi@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+            },
+            "has-unicode": {
+                "version": "1.0.1",
+                "from": "has-unicode@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+            },
+            "hawk": {
+                "version": "3.1.2",
+                "from": "hawk@>=3.1.0 <3.2.0",
+                "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+            },
+            "hoek": {
+                "version": "2.16.3",
+                "from": "hoek@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+            },
+            "hosted-git-info": {
+                "version": "2.1.4",
+                "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+            },
+            "http-signature": {
+                "version": "1.1.0",
+                "from": "http-signature@>=1.1.0 <1.2.0",
+                "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+            },
+            "indent-string": {
+                "version": "2.1.0",
+                "from": "indent-string@>=2.1.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
+            },
+            "inflight": {
+                "version": "1.0.4",
+                "from": "inflight@>=1.0.4 <2.0.0",
+                "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
+            },
+            "inherits": {
+                "version": "2.0.1",
+                "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "ini": {
+                "version": "1.3.4",
+                "from": "ini@>=1.2.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
+            "inline-source-map": {
+                "version": "0.5.0",
+                "from": "inline-source-map@>=0.5.0 <0.6.0",
+                "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+                "dependencies": {
+                    "source-map": {
+                        "version": "0.4.4",
+                        "from": "source-map@>=0.4.0 <0.5.0",
+                        "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+                    }
+                }
+            },
+            "invert-kv": {
+                "version": "1.0.0",
+                "from": "invert-kv@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+            },
+            "is-absolute": {
+                "version": "0.1.7",
+                "from": "is-absolute@>=0.1.7 <0.2.0",
+                "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
+            },
+            "is-arrayish": {
+                "version": "0.2.1",
+                "from": "is-arrayish@>=0.2.1 <0.3.0",
+                "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+            },
+            "is-buffer": {
+                "version": "1.1.0",
+                "from": "is-buffer@>=1.0.2 <2.0.0",
+                "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+            },
+            "is-builtin-module": {
+                "version": "1.0.0",
+                "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+            },
+            "is-finite": {
+                "version": "1.0.1",
+                "from": "is-finite@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+            },
+            "is-fullwidth-code-point": {
+                "version": "1.0.0",
+                "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+            },
+            "is-my-json-valid": {
+                "version": "2.12.3",
+                "from": "is-my-json-valid@>=2.12.3 <3.0.0",
+                "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+            },
+            "is-property": {
+                "version": "1.0.2",
+                "from": "is-property@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+            },
+            "is-relative": {
+                "version": "0.1.3",
+                "from": "is-relative@>=0.1.0 <0.2.0",
+                "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+            },
+            "is-typedarray": {
+                "version": "1.0.0",
+                "from": "is-typedarray@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "is-utf8": {
+                "version": "0.2.0",
+                "from": "is-utf8@>=0.2.0 <0.3.0",
+                "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+            },
+            "isarray": {
+                "version": "0.0.1",
+                "from": "isarray@0.0.1",
+                "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "isstream": {
+                "version": "0.1.2",
+                "from": "isstream@>=0.1.2 <0.2.0",
+                "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "jodid25519": {
+                "version": "1.0.2",
+                "from": "jodid25519@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+            },
+            "jsbn": {
+                "version": "0.1.0",
+                "from": "jsbn@>=0.1.0 <0.2.0",
+                "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+            },
+            "json-schema": {
+                "version": "0.2.2",
+                "from": "json-schema@0.2.2",
+                "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+            },
+            "json-stringify-safe": {
+                "version": "5.0.1",
+                "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "jsonpointer": {
+                "version": "2.0.0",
+                "from": "jsonpointer@2.0.0",
+                "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+            },
+            "JSONStream": {
+                "version": "1.0.7",
+                "from": "JSONStream@1.0.7",
+                "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                "dependencies": {
+                    "jsonparse": {
+                        "version": "1.2.0",
+                        "from": "jsonparse@>=1.1.0 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+                    }
+                }
+            },
+            "jsprim": {
+                "version": "1.2.2",
+                "from": "jsprim@>=1.2.2 <2.0.0",
+                "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+            },
+            "kind-of": {
+                "version": "2.0.1",
+                "from": "kind-of@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+            },
+            "lazy-cache": {
+                "version": "0.2.4",
+                "from": "lazy-cache@>=0.2.4 <0.3.0",
+                "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+            },
+            "lcid": {
+                "version": "1.0.0",
+                "from": "lcid@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+            },
+            "load-json-file": {
+                "version": "1.1.0",
+                "from": "load-json-file@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                "dependencies": {
+                    "graceful-fs": {
+                        "version": "4.1.2",
+                        "from": "graceful-fs@>=4.1.2 <5.0.0",
+                        "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    }
+                }
+            },
+            "lodash": {
+                "version": "3.10.1",
+                "from": "lodash@>=3.1.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "lodash._basetostring": {
+                "version": "3.0.1",
+                "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+            },
+            "lodash._createpadding": {
+                "version": "3.6.1",
+                "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+            },
+            "lodash.memoize": {
+                "version": "3.0.4",
+                "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+            },
+            "lodash.pad": {
+                "version": "3.1.1",
+                "from": "lodash.pad@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+            },
+            "lodash.padleft": {
+                "version": "3.1.1",
+                "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+            },
+            "lodash.padright": {
+                "version": "3.1.1",
+                "from": "lodash.padright@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+            },
+            "lodash.repeat": {
+                "version": "3.0.1",
+                "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+            },
+            "longest": {
+                "version": "1.0.1",
+                "from": "longest@>=1.0.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+            },
+            "loud-rejection": {
+                "version": "1.2.0",
+                "from": "loud-rejection@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
+            },
+            "lru-cache": {
+                "version": "3.2.0",
+                "from": "lru-cache@>=3.2.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz"
+            },
+            "map-obj": {
+                "version": "1.0.1",
+                "from": "map-obj@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+            },
+            "meow": {
+                "version": "3.6.0",
+                "from": "meow@>=3.3.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                "dependencies": {
+                    "minimist": {
+                        "version": "1.2.0",
+                        "from": "minimist@>=1.1.3 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                }
+            },
+            "mime-db": {
+                "version": "1.20.0",
+                "from": "mime-db@>=1.20.0 <1.21.0",
+                "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+            },
+            "mime-types": {
+                "version": "2.1.8",
+                "from": "mime-types@>=2.1.7 <2.2.0",
+                "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
+            },
+            "minimatch": {
+                "version": "3.0.0",
+                "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+            },
+            "minimist": {
+                "version": "0.0.8",
+                "from": "minimist@0.0.8",
+                "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            },
+            "mkdirp": {
+                "version": "0.5.1",
+                "from": "mkdirp@>=0.5.0 <0.6.0",
+                "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+            },
+            "modernizr": {
+                "version": "3.2.0",
+                "from": "modernizr@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/modernizr/-/modernizr-3.2.0.tgz",
+                "dependencies": {
+                    "camelcase": {
+                        "version": "1.2.1",
+                        "from": "camelcase@>=1.2.1 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "marked": {
+                        "version": "0.3.5",
+                        "from": "marked@0.3.5",
+                        "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
+                    },
+                    "requirejs": {
+                        "version": "2.1.20",
+                        "from": "requirejs@2.1.20",
+                        "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
+                    },
+                    "yargs": {
+                        "version": "3.29.0",
+                        "from": "yargs@3.29.0",
+                        "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz"
+                    }
+                }
+            },
+            "module-deps": {
+                "version": "3.9.1",
+                "from": "module-deps@3.9.1",
+                "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz"
+            },
+            "ms": {
+                "version": "0.7.1",
+                "from": "ms@0.7.1",
+                "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            },
+            "nan": {
+                "version": "2.1.0",
+                "from": "nan@>=2.0.8 <3.0.0",
+                "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+            },
+            "node-gyp": {
+                "version": "3.2.1",
+                "from": "node-gyp@>=3.0.1 <4.0.0",
+                "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
+                "dependencies": {
+                    "glob": {
+                        "version": "4.5.3",
+                        "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                        "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                        "dependencies": {
+                            "minimatch": {
+                                "version": "2.0.10",
+                                "from": "minimatch@>=2.0.1 <3.0.0",
+                                "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+                            }
+                        }
+                    },
+                    "graceful-fs": {
+                        "version": "4.1.2",
+                        "from": "graceful-fs@>=4.1.2 <5.0.0",
+                        "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "lru-cache": {
+                        "version": "2.7.3",
+                        "from": "lru-cache@>=2.0.0 <3.0.0",
+                        "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "minimatch": {
+                        "version": "1.0.0",
+                        "from": "minimatch@>=1.0.0 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz"
+                    }
+                }
+            },
+            "node-sass": {
+                "version": "3.4.2",
+                "from": "node-sass@3.4.2",
+                "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz",
+                "dependencies": {
+                    "glob": {
+                        "version": "5.0.15",
+                        "from": "glob@>=5.0.14 <6.0.0",
+                        "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+                    }
+                }
+            },
+            "node-uuid": {
+                "version": "1.4.7",
+                "from": "node-uuid@>=1.4.7 <1.5.0",
+                "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+            },
+            "nopt": {
+                "version": "3.0.6",
+                "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+            },
+            "normalize-package-data": {
+                "version": "2.3.5",
+                "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+            },
+            "npmconf": {
+                "version": "2.1.2",
+                "from": "npmconf@>=2.1.2 <3.0.0",
+                "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+                "dependencies": {
+                    "semver": {
+                        "version": "4.3.6",
+                        "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                        "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                    }
+                }
+            },
+            "npmlog": {
+                "version": "1.2.1",
+                "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
+            },
+            "number-is-nan": {
+                "version": "1.0.0",
+                "from": "number-is-nan@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+            },
+            "oauth-sign": {
+                "version": "0.8.0",
+                "from": "oauth-sign@>=0.8.0 <0.9.0",
+                "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+            },
+            "object-assign": {
+                "version": "4.0.1",
+                "from": "object-assign@>=4.0.1 <5.0.0",
+                "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+            },
+            "once": {
+                "version": "1.3.3",
+                "from": "once@>=1.3.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+            },
+            "os-homedir": {
+                "version": "1.0.1",
+                "from": "os-homedir@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+            },
+            "os-locale": {
+                "version": "1.4.0",
+                "from": "os-locale@>=1.4.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+            },
+            "os-shim": {
+                "version": "0.1.3",
+                "from": "os-shim@>=0.1.2 <0.2.0",
+                "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+            },
+            "os-tmpdir": {
+                "version": "1.0.1",
+                "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+            },
+            "osenv": {
+                "version": "0.1.3",
+                "from": "osenv@>=0.0.0 <1.0.0",
+                "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
+            },
+            "parents": {
+                "version": "1.0.1",
+                "from": "parents@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz"
+            },
+            "parse-json": {
+                "version": "2.2.0",
+                "from": "parse-json@>=2.2.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+            },
+            "path-array": {
+                "version": "1.0.0",
+                "from": "path-array@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz"
+            },
+            "path-exists": {
+                "version": "2.1.0",
+                "from": "path-exists@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+            },
+            "path-is-absolute": {
+                "version": "1.0.0",
+                "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "path-platform": {
+                "version": "0.11.15",
+                "from": "path-platform@>=0.11.15 <0.12.0",
+                "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+            },
+            "path-type": {
+                "version": "1.1.0",
+                "from": "path-type@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                "dependencies": {
+                    "graceful-fs": {
+                        "version": "4.1.2",
+                        "from": "graceful-fs@>=4.1.2 <5.0.0",
+                        "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    }
+                }
+            },
+            "pify": {
+                "version": "2.3.0",
+                "from": "pify@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+            },
+            "pinkie": {
+                "version": "2.0.1",
+                "from": "pinkie@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+            },
+            "pinkie-promise": {
+                "version": "2.0.0",
+                "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+            },
+            "process-nextick-args": {
+                "version": "1.0.6",
+                "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+            },
+            "proto-list": {
+                "version": "1.2.4",
+                "from": "proto-list@>=1.2.1 <1.3.0",
+                "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+            },
+            "pseudomap": {
+                "version": "1.0.1",
+                "from": "pseudomap@>=1.0.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.1.tgz"
+            },
+            "qs": {
+                "version": "5.2.0",
+                "from": "qs@>=5.2.0 <5.3.0",
+                "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+            },
+            "read-pkg": {
+                "version": "1.1.0",
+                "from": "read-pkg@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+            },
+            "read-pkg-up": {
+                "version": "1.0.1",
+                "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+            },
+            "readable-stream": {
+                "version": "1.1.13",
+                "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+                "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+            },
+            "redent": {
+                "version": "1.0.0",
+                "from": "redent@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+            },
+            "repeat-string": {
+                "version": "1.5.2",
+                "from": "repeat-string@>=1.5.2 <2.0.0",
+                "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+            },
+            "repeating": {
+                "version": "2.0.0",
+                "from": "repeating@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
+            },
+            "request": {
+                "version": "2.67.0",
+                "from": "request@>=2.61.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+            },
+            "resolve": {
+                "version": "1.1.6",
+                "from": "resolve@>=1.1.3 <2.0.0",
+                "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "right-align": {
+                "version": "0.1.3",
+                "from": "right-align@>=0.1.1 <0.2.0",
+                "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+            },
+            "rimraf": {
+                "version": "2.4.4",
+                "from": "rimraf@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+                "dependencies": {
+                    "glob": {
+                        "version": "5.0.15",
+                        "from": "glob@>=5.0.14 <6.0.0",
+                        "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+                    }
+                }
+            },
+            "sass-graph": {
+                "version": "2.0.1",
+                "from": "sass-graph@>=2.0.1 <3.0.0",
+                "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+                "dependencies": {
+                    "glob": {
+                        "version": "5.0.15",
+                        "from": "glob@>=5.0.5 <6.0.0",
+                        "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+                    },
+                    "yargs": {
+                        "version": "3.31.0",
+                        "from": "yargs@>=3.8.0 <4.0.0",
+                        "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.31.0.tgz"
+                    }
+                }
+            },
+            "semver": {
+                "version": "5.1.0",
+                "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+            },
+            "sigmund": {
+                "version": "1.0.1",
+                "from": "sigmund@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            },
+            "signal-exit": {
+                "version": "2.1.2",
+                "from": "signal-exit@>=2.1.2 <3.0.0",
+                "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+            },
+            "sntp": {
+                "version": "1.0.9",
+                "from": "sntp@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+            },
+            "spawn-sync": {
+                "version": "1.0.13",
+                "from": "spawn-sync@1.0.13",
+                "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.13.tgz"
+            },
+            "spdx-correct": {
+                "version": "1.0.2",
+                "from": "spdx-correct@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+            },
+            "spdx-exceptions": {
+                "version": "1.0.4",
+                "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+            },
+            "spdx-expression-parse": {
+                "version": "1.0.2",
+                "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+            },
+            "spdx-license-ids": {
+                "version": "1.1.0",
+                "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+            },
+            "sshpk": {
+                "version": "1.7.1",
+                "from": "sshpk@>=1.7.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                "dependencies": {
+                    "assert-plus": {
+                        "version": "0.2.0",
+                        "from": "assert-plus@>=0.2.0 <0.3.0",
+                        "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    }
+                }
+            },
+            "stream-combiner2": {
+                "version": "1.0.2",
+                "from": "stream-combiner2@>=1.0.0 <1.1.0",
+                "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                "dependencies": {
+                    "readable-stream": {
+                        "version": "1.0.33",
+                        "from": "readable-stream@>=1.0.17 <1.1.0",
+                        "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+                    },
+                    "through2": {
+                        "version": "0.5.1",
+                        "from": "through2@>=0.5.1 <0.6.0",
+                        "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+                    },
+                    "xtend": {
+                        "version": "3.0.0",
+                        "from": "xtend@>=3.0.0 <3.1.0",
+                        "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                }
+            },
+            "string_decoder": {
+                "version": "0.10.31",
+                "from": "string_decoder@>=0.10.0 <0.11.0",
+                "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "string-width": {
+                "version": "1.0.1",
+                "from": "string-width@>=1.0.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+            },
+            "stringstream": {
+                "version": "0.0.5",
+                "from": "stringstream@>=0.0.4 <0.1.0",
+                "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "strip-ansi": {
+                "version": "3.0.0",
+                "from": "strip-ansi@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+            },
+            "strip-bom": {
+                "version": "2.0.0",
+                "from": "strip-bom@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+            },
+            "strip-indent": {
+                "version": "1.0.1",
+                "from": "strip-indent@>=1.0.1 <2.0.0",
+                "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+            },
+            "subarg": {
+                "version": "1.0.0",
+                "from": "subarg@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+                "dependencies": {
+                    "minimist": {
+                        "version": "1.2.0",
+                        "from": "minimist@>=1.1.0 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                }
+            },
+            "supports-color": {
+                "version": "2.0.0",
+                "from": "supports-color@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            },
+            "tar": {
+                "version": "2.2.1",
+                "from": "tar@>=2.0.0 <3.0.0",
+                "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+            },
+            "through": {
+                "version": "2.3.8",
+                "from": "through@>=2.2.7 <3.0.0",
+                "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            },
+            "through2": {
+                "version": "1.1.1",
+                "from": "through2@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+            },
+            "tough-cookie": {
+                "version": "2.2.1",
+                "from": "tough-cookie@>=2.2.0 <2.3.0",
+                "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+            },
+            "trim-newlines": {
+                "version": "1.0.0",
+                "from": "trim-newlines@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+            },
+            "tunnel-agent": {
+                "version": "0.4.1",
+                "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            },
+            "tweetnacl": {
+                "version": "0.13.2",
+                "from": "tweetnacl@>=0.13.0 <1.0.0",
+                "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+            },
+            "typedarray": {
+                "version": "0.0.6",
+                "from": "typedarray@>=0.0.5 <0.1.0",
+                "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "uglify-js": {
+                "version": "2.6.1",
+                "from": "uglify-js@2.6.1",
+                "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+                "dependencies": {
+                    "source-map": {
+                        "version": "0.5.3",
+                        "from": "source-map@>=0.5.1 <0.6.0",
+                        "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    }
+                }
+            },
+            "uglify-to-browserify": {
+                "version": "1.0.2",
+                "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+            },
+            "uid-number": {
+                "version": "0.0.5",
+                "from": "uid-number@0.0.5",
+                "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+            },
+            "umd": {
+                "version": "3.0.1",
+                "from": "umd@>=3.0.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+            },
+            "util-deprecate": {
+                "version": "1.0.2",
+                "from": "util-deprecate@>=1.0.1 <1.1.0",
+                "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            },
+            "validate-npm-package-license": {
+                "version": "3.0.1",
+                "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+            },
+            "verror": {
+                "version": "1.3.6",
+                "from": "verror@1.3.6",
+                "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+            },
+            "which": {
+                "version": "1.2.0",
+                "from": "which@>=1.2.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz"
+            },
+            "window-size": {
+                "version": "0.1.4",
+                "from": "window-size@>=0.1.4 <0.2.0",
+                "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+            },
+            "wrap-ansi": {
+                "version": "1.0.0",
+                "from": "wrap-ansi@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
+            },
+            "wrappy": {
+                "version": "1.0.1",
+                "from": "wrappy@>=1.0.0 <2.0.0",
+                "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            },
+            "xtend": {
+                "version": "4.0.1",
+                "from": "xtend@>=4.0.0 <4.1.0-0",
+                "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            },
+            "y18n": {
+                "version": "3.2.0",
+                "from": "y18n@>=3.2.0 <4.0.0",
+                "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+            },
+            "yargs": {
+                "version": "3.10.0",
+                "from": "yargs@>=3.10.0 <3.11.0",
+                "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                "dependencies": {
+                    "camelcase": {
+                        "version": "1.2.1",
+                        "from": "camelcase@>=1.0.2 <2.0.0",
+                        "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                        "version": "2.1.0",
+                        "from": "cliui@>=2.1.0 <3.0.0",
+                        "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+                    },
+                    "window-size": {
+                        "version": "0.1.0",
+                        "from": "window-size@0.1.0",
+                        "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                        "version": "0.0.2",
+                        "from": "wordwrap@0.0.2"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,36 +11,36 @@
         "koala-framework/library-silkicons": "1.3",
         "koala-framework/library-htmlawed": "1.1.14",
         "koala-framework/library-css3pie": "1.0.0",
-        "koala-framework/composer-extra-assets": "1.1.*",
+        "koala-framework/composer-extra-assets": "^2.0",
         "koala-framework/kwf-trl-jsparser": "dev-master",
-        "twig/twig": "1.16.1",
-        "koala-framework/sourcemaps": "~0.4.0",
+        "twig/twig": "^1.16.1",
+        "koala-framework/sourcemaps": "^0.4",
         "koala-framework/file-watcher": "*",
-        "symfony/console": "~2.5",
-        "symfony/process": "~2.5",
-        "sepia/po-parser": "4.2.1",
-        "jbroadway/urlify": "1.0.5-stable"
+        "symfony/console": "^2.5",
+        "symfony/process": "^2.5",
+        "sepia/po-parser": "^4.2.1",
+        "jbroadway/urlify": "^1.0.5"
     },
     "extra": {
         "require-bower": {
             "jquery": "~1.11 || 2.*",
-            "underscore": "1.7.0",
+            "underscore": "^1.7.0",
             "compass-mixins": "koala-framework/compass-mixins#7319116335050516e01b250b6e771600ab55e105",
             "tinymce": "tinymce/tinymce#4.1.9",
-            "matches-selector": "1.0.3"
+            "matches-selector": "^1.0.3"
         },
         "require-npm": {
-            "uglify-js": "2.4.13",
-            "node-sass": "3.4.2",
-            "amdlc": "0.1.5",
-            "esprima": "1.2.2",
-            "browser-pack": "5.0.1",
-            "module-deps": "3.8.0",
-            "JSONStream": "1.0.4",
-            "modernizr": "git://github.com/Modernizr/Modernizr.git#eb211bbcb"
+            "uglify-js": "^2.4.13",
+            "node-sass": "^3.4.2",
+            "amdlc": "^0.1.5",
+            "esprima": "^1.2.2",
+            "browser-pack": "^5.0.1",
+            "module-deps": "^3.8.0",
+            "JSONStream": "^1.0.4",
+            "modernizr": "^3.0.0"
         },
         "require-dev-bower": {
-            "qunit": "1.18.0",
+            "qunit": "^1.18.0",
             "qunit-phantomjs-runner": "vivid-planet/qunit-phantomjs-runner#e96347ee33b773160cf061d7b1b5c4ad3d1d9082"
         },
         "kwf": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8ef348436093186230151cee45119dc0",
-    "content-hash": "53ef5b57c2670397edd295d1cd19fa35",
+    "hash": "f0076db837adb9dde3a3dff0fd976b60",
+    "content-hash": "107772563305fbfebed107714aed5d22",
     "packages": [
         {
             "name": "jbroadway/urlify",
-            "version": "1.0.5-stable",
+            "version": "1.0.6-stable",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jbroadway/urlify.git",
-                "reference": "b5f13d860d9da34e4adece6a93e46e0292ab6aa7"
+                "reference": "bb9128ccd1d828ddebdd0ad15e5dcb9cd88b3398"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jbroadway/urlify/zipball/b5f13d860d9da34e4adece6a93e46e0292ab6aa7",
-                "reference": "b5f13d860d9da34e4adece6a93e46e0292ab6aa7",
+                "url": "https://api.github.com/repos/jbroadway/urlify/zipball/bb9128ccd1d828ddebdd0ad15e5dcb9cd88b3398",
+                "reference": "bb9128ccd1d828ddebdd0ad15e5dcb9cd88b3398",
                 "shasum": ""
             },
             "require": {
@@ -59,25 +59,28 @@
                 "url",
                 "urlify"
             ],
-            "time": "2015-05-29 13:53:37"
+            "time": "2015-10-15 16:53:33"
         },
         {
             "name": "koala-framework/composer-extra-assets",
-            "version": "v1.1.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/koala-framework/composer-extra-assets.git",
-                "reference": "4860eb4c7041824559962a0fc1a3b139fc501444"
+                "reference": "ffe6f559f56f21ecb2d00b1c916a5310a1e1420f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koala-framework/composer-extra-assets/zipball/4860eb4c7041824559962a0fc1a3b139fc501444",
-                "reference": "4860eb4c7041824559962a0fc1a3b139fc501444",
+                "url": "https://api.github.com/repos/koala-framework/composer-extra-assets/zipball/ffe6f559f56f21ecb2d00b1c916a5310a1e1420f",
+                "reference": "ffe6f559f56f21ecb2d00b1c916a5310a1e1420f",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "1.0.0",
-                "mouf/nodejs-installer": "~1.0"
+                "composer-plugin-api": "^1.0",
+                "mouf/nodejs-installer": ">=1.0.2 <2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.5.*"
             },
             "type": "composer-plugin",
             "extra": {
@@ -102,7 +105,7 @@
             ],
             "description": "Composer Plugin for installing Assets using native npm/bower",
             "homepage": "https://github.com/koala-framework/composer-extra-assets",
-            "time": "2015-03-19 16:07:24"
+            "time": "2015-08-25 15:54:19"
         },
         {
             "name": "koala-framework/extjs2",
@@ -172,16 +175,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/koala-framework/kwf-trl-jsparser.git",
-                "reference": "2041fc82d42f106ca6a95e3836357525e6f8108c"
+                "reference": "7571b0c366682d4d5ba565afb2719fc5fe00723c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koala-framework/kwf-trl-jsparser/zipball/2041fc82d42f106ca6a95e3836357525e6f8108c",
-                "reference": "2041fc82d42f106ca6a95e3836357525e6f8108c",
+                "url": "https://api.github.com/repos/koala-framework/kwf-trl-jsparser/zipball/7571b0c366682d4d5ba565afb2719fc5fe00723c",
+                "reference": "7571b0c366682d4d5ba565afb2719fc5fe00723c",
                 "shasum": ""
             },
             "require": {
-                "koala-framework/composer-extra-assets": "~1.1",
+                "koala-framework/composer-extra-assets": "~1.1 || ~2.0",
                 "symfony/process": "~2.5"
             },
             "require-dev": {
@@ -200,7 +203,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Parses js code for trl-calls and returns list",
-            "time": "2015-11-06 08:15:09"
+            "time": "2015-12-07 05:22:17"
         },
         {
             "name": "koala-framework/library-css3pie",
@@ -333,16 +336,16 @@
         },
         {
             "name": "koala-framework/sourcemaps",
-            "version": "dev-master",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/koala-framework/sourcemaps.git",
-                "reference": "0820494f213159d65ac93c31f5881a0a05d3450a"
+                "reference": "187ec30eb143e96a92ce14ab911b97e443f622c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/koala-framework/sourcemaps/zipball/0820494f213159d65ac93c31f5881a0a05d3450a",
-                "reference": "0820494f213159d65ac93c31f5881a0a05d3450a",
+                "url": "https://api.github.com/repos/koala-framework/sourcemaps/zipball/187ec30eb143e96a92ce14ab911b97e443f622c5",
+                "reference": "187ec30eb143e96a92ce14ab911b97e443f622c5",
                 "shasum": ""
             },
             "require-dev": {
@@ -365,7 +368,7 @@
             ],
             "description": "Sourcemaps Utities",
             "homepage": "http://www.koala-framework.org/",
-            "time": "2015-11-20 08:11:58"
+            "time": "2015-11-26 16:56:01"
         },
         {
             "name": "koala-framework/zendframework1",
@@ -558,25 +561,26 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.7",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750"
+                "reference": "d232bfc100dfd32b18ccbcab4bcc8f28697b7e41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/16bb1cb86df43c90931df65f529e7ebd79636750",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d232bfc100dfd32b18ccbcab4bcc8f28697b7e41",
+                "reference": "d232bfc100dfd32b18ccbcab4bcc8f28697b7e41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -586,7 +590,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -613,20 +617,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 09:54:26"
+            "time": "2015-11-30 12:35:10"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.7",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7e2f9c31645680026c2372edf66f863fc7757af5"
+                "reference": "a5eb815363c0388e83247e7e9853e5dbc14999cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7e2f9c31645680026c2372edf66f863fc7757af5",
-                "reference": "7e2f9c31645680026c2372edf66f863fc7757af5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a5eb815363c0388e83247e7e9853e5dbc14999cc",
+                "reference": "a5eb815363c0388e83247e7e9853e5dbc14999cc",
                 "shasum": ""
             },
             "require": {
@@ -634,10 +638,10 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.3"
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -646,7 +650,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -673,20 +677,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-30 20:10:21"
+            "time": "2015-10-30 20:15:42"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.7",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a06a0c0ff7db3736a50d530c908cca547bf13da9"
+                "reference": "ead9b07af4ba77b6507bee697396a5c79e633f08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a06a0c0ff7db3736a50d530c908cca547bf13da9",
-                "reference": "a06a0c0ff7db3736a50d530c908cca547bf13da9",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ead9b07af4ba77b6507bee697396a5c79e633f08",
+                "reference": "ead9b07af4ba77b6507bee697396a5c79e633f08",
                 "shasum": ""
             },
             "require": {
@@ -695,7 +699,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -722,20 +726,76 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-30 20:10:21"
+            "time": "2015-10-30 20:15:42"
         },
         {
-            "name": "symfony/process",
-            "version": "v2.7.7",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f6290983c8725d0afa29bdc3e5295879de3e58f5",
-                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0b6a8940385311a24e060ec1fe35680e17c74497",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2015-11-04 20:28:58"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "1b988a88e3551102f3c2d9e1d47a18c3a78d6312"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1b988a88e3551102f3c2d9e1d47a18c3a78d6312",
+                "reference": "1b988a88e3551102f3c2d9e1d47a18c3a78d6312",
                 "shasum": ""
             },
             "require": {
@@ -744,7 +804,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -771,29 +831,33 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-19 16:11:24"
+            "time": "2015-11-30 12:35:10"
         },
         {
             "name": "twig/twig",
-            "version": "v1.16.1",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7c4c01dcf578523cfcddf383641a4f12790270ec"
+                "reference": "d9b6333ae8dd2c8e3fd256e127548def0bc614c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7c4c01dcf578523cfcddf383641a4f12790270ec",
-                "reference": "7c4c01dcf578523cfcddf383641a4f12790270ec",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/d9b6333ae8dd2c8e3fd256e127548def0bc614c6",
+                "reference": "d9b6333ae8dd2c8e3fd256e127548def0bc614c6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.4"
+                "php": ">=5.2.7"
+            },
+            "require-dev": {
+                "symfony/debug": "~2.7",
+                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.23-dev"
                 }
             },
             "autoload": {
@@ -819,7 +883,7 @@
                 },
                 {
                     "name": "Twig Team",
-                    "homepage": "https://github.com/fabpot/Twig/graphs/contributors",
+                    "homepage": "http://twig.sensiolabs.org/contributors",
                     "role": "Contributors"
                 }
             ],
@@ -828,7 +892,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2014-10-10 14:09:53"
+            "time": "2015-11-05 12:49:06"
         }
     ],
     "packages-dev": [
@@ -1365,28 +1429,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "2b0112e42c338afa9ad9dfeb94d66f6d84c2f828"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/2b0112e42c338afa9ad9dfeb94d66f6d84c2f828",
+                "reference": "2b0112e42c338afa9ad9dfeb94d66f6d84c2f828",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1409,11 +1473,11 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-06 07:21:36"
         },
         {
             "name": "sebastian/exporter",
@@ -1483,16 +1547,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -1532,20 +1596,20 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.7",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4cfcd7a9fceba662b3c036b7d9a91f6197af046c"
+                "reference": "f79824187de95064a2f5038904c4d7f0227fedb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4cfcd7a9fceba662b3c036b7d9a91f6197af046c",
-                "reference": "4cfcd7a9fceba662b3c036b7d9a91f6197af046c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f79824187de95064a2f5038904c4d7f0227fedb5",
+                "reference": "f79824187de95064a2f5038904c4d7f0227fedb5",
                 "shasum": ""
             },
             "require": {
@@ -1554,7 +1618,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1581,21 +1645,13 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 13:41:01"
+            "time": "2015-11-30 12:35:10"
         }
     ],
-    "aliases": [
-        {
-            "alias": "0.3.0",
-            "alias_normalized": "0.3.0.0",
-            "version": "9999999-dev",
-            "package": "koala-framework/sourcemaps"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "koala-framework/kwf-trl-jsparser": 20,
-        "koala-framework/sourcemaps": 20
+        "koala-framework/kwf-trl-jsparser": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
composer-extra-assets 2.0 adds a lock for npm and bower dependencies