### PR TITLE
Add and animate loadinganimation only when it comes into view.

### DIFF
--- a/Kwc/Abstract/Image/Component.php
+++ b/Kwc/Abstract/Image/Component.php
@@ -132,7 +132,6 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
         if ($this->_getSetting('defineWidth')) $ret['style'] .= 'width:'.$ret['width'].'px;';
 
         $ret['containerClass'] = $this->_getBemClass("container").' kwfUp-kwcImageContainer ';
-        if ($ret['width'] > 100) $ret['containerClass'] .= ' kwfUp-webResponsiveImgLoading';
         if (!$this->_getSetting('lazyLoadOutOfViewport')) $ret['containerClass'] .= ' kwfUp-loadImmediately';
 
         $ret['imgCssClass'] = $this->_getSetting('imgCssClass');

--- a/Kwc/Form/Component.twig
+++ b/Kwc/Form/Component.twig
@@ -35,7 +35,6 @@
             {% endif %}
             <div class="kwfUp-submitWrapper {{ 'submitWrapper'|bemClass }}">
                 <div class="kwfUp-button {{ 'button'|bemClass }}">
-                    <div class="kwfUp-saving {{ 'saving'|bemClass }}"></div>
                     <button class="kwfUp-submit {{ 'submit'|bemClass }}" type="submit" name="{{ formName }}" value="submit">
                         <span>{{ placeholder.submitButton }}</span>
                     </button>

--- a/commonjs/frontend-form/form.js
+++ b/commonjs/frontend-form/form.js
@@ -188,7 +188,7 @@ FormComponent.prototype = {
     submit: function()
     {
         var button = this.el.find('.kwfUp-submitWrapper .kwfUp-button');
-        button.find('.kwfUp-saving').show();
+        button.prepend('<div class="kwfUp-saving"></div>');
         button.find('.kwfUp-submit').hide();
 
         this.errorStyle.hideErrors();
@@ -230,7 +230,7 @@ FormComponent.prototype = {
                 }
 
                 if (!r.successUrl) {
-                    button.find('.kwfUp-saving').hide();
+                    button.find('.kwfUp-saving').remove();
                     button.find('.kwfUp-submit').show();
                 }
 

--- a/commonjs/responsive-img.js
+++ b/commonjs/responsive-img.js
@@ -75,6 +75,9 @@ function getResponsiveWidthSteps(minWidth, maxWidth) {
 function initResponsiveImgEl(el) {
     var elWidth = getCachedWidth(el);
     if (elWidth == 0) return;
+    if (elWidth > 100) {
+        el.addClass('kwfUp-webResponsiveImgLoading');
+    }
     el[0].responsiveImgInitDone = true; //don't save as el.data to avoid getting it copied when cloning elements
     var devicePixelRatio = window.devicePixelRatio ? window.devicePixelRatio : 1;
     var baseUrl = el.data("src");


### PR DESCRIPTION
With multiple images on a page, multiple loadinganimation will be animated.
This causes overall animation performance issues, for example with parallax effekt on a big image.