### PR TITLE
Text is masked on cached form

### DIFF
--- a/Kwc/Form/Field/Abstract/Component.php
+++ b/Kwc/Form/Field/Abstract/Component.php
@@ -16,6 +16,7 @@ class Kwc_Form_Field_Abstract_Component extends Kwc_Abstract
     public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer = null)
     {
         $ret = parent::getTemplateVars($renderer);
+        $this->getFormField()->trlStaticExecute($this->getData()->getLanguage());
         $form = $this->_getForm();
 
         //initialize form, sets formName on fields

--- a/Kwc/Form/Field/Abstract/Trl/Component.php
+++ b/Kwc/Form/Field/Abstract/Trl/Component.php
@@ -14,6 +14,7 @@ class Kwc_Form_Field_Abstract_Trl_Component extends Kwc_Chained_Trl_Component
     public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer = null)
     {
         $ret = Kwc_Abstract::getTemplateVars($renderer);
+        $this->getFormField()->trlStaticExecute($this->getData()->getLanguage());
         $form = $this->_getForm();
 
         //initialize form, sets formName on fields


### PR DESCRIPTION
trlStaticExecute is only called if form is not cached. getFormField
is always called so also call trlStaticExecute. Fixes problems
introduced with 61ab772704dc34aa57696b4a3daab3de97afed50