### PR TITLE
Fix MySQL 5.7 error 42000 in update script

### DIFF
--- a/Kwf/Update/20150309Legacy39000.php
+++ b/Kwf/Update/20150309Legacy39000.php
@@ -51,6 +51,7 @@ class Kwf_Update_20150309Legacy39000 extends Kwf_Update
             }
             $db->query("ALTER TABLE `kwf_uploads` CHANGE  `id`  `id_old` INT( 11 )");
             $db->query("ALTER TABLE `kwf_uploads` DROP PRIMARY KEY");
+            $db->query("ALTER TABLE `kwf_uploads` MODIFY `id_old` INT( 11 ) NULL");
             $db->query("ALTER TABLE `kwf_uploads` ADD  `id` VARBINARY( 36 ) NOT NULL FIRST");
             $db->query("UPDATE `kwf_uploads` SET `id` = UUID()");
             $db->query("ALTER TABLE `kwf_uploads` ADD PRIMARY KEY(`id`)");

--- a/Kwf/Update/20150309Legacy39000.php
+++ b/Kwf/Update/20150309Legacy39000.php
@@ -49,7 +49,7 @@ class Kwf_Update_20150309Legacy39000 extends Kwf_Update
                 $sql = "ALTER TABLE {$index['TABLE_NAME']} DROP FOREIGN KEY `{$index['CONSTRAINT_NAME']}`";
                 $db->query($sql);
             }
-            $db->query("ALTER TABLE `kwf_uploads` CHANGE  `id`  `id_old` INT( 11 ) NULL");
+            $db->query("ALTER TABLE `kwf_uploads` CHANGE  `id`  `id_old` INT( 11 )");
             $db->query("ALTER TABLE `kwf_uploads` DROP PRIMARY KEY");
             $db->query("ALTER TABLE `kwf_uploads` ADD  `id` VARBINARY( 36 ) NOT NULL FIRST");
             $db->query("UPDATE `kwf_uploads` SET `id` = UUID()");


### PR DESCRIPTION
Breaking change in 5.7:
```
Columns in a PRIMARY KEY must be NOT NULL, but if declared explicitly as NULL produced no 
error. Now an error occurs. For example, a statement such as CREATE TABLE t (i INT NULL 
PRIMARY KEY) is rejected. The same occurs for similar ALTER TABLE statements. 
(Bug #13995622, Bug #66987, Bug #15967545, Bug #16545198)
```

Error message:
https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_primary_cant_have_null

Screen from  kwf-app-demo ext 4 branch installation:
![screenshot_111](https://cloud.githubusercontent.com/assets/7556290/14773353/d9a671b8-0af4-11e6-8f00-08ac23d24478.png)

How `kwf_uploads` looks after fix:
![image](https://cloud.githubusercontent.com/assets/7556290/14773394/45d85e6e-0af5-11e6-8bfa-729d1e0bd6a1.png)

p.s. How to enable fix from 3.9 branch to other (3.10, 3.11 etc) branches? =)