### PR TITLE
Add preliminaryDomain config setting

### DIFF
--- a/Kwc/Root/DomainRoot/Model.php
+++ b/Kwc/Root/DomainRoot/Model.php
@@ -2,7 +2,7 @@
 class Kwc_Root_DomainRoot_Model extends Kwf_Model_Data_Abstract
 {
     private $_domains;
-    protected $_columns = array('id', 'name', 'domain', 'component', 'pattern');
+    protected $_columns = array('id', 'name', 'domain', 'preliminary_domain', 'component', 'pattern');
     protected $_toStringField = 'name';
 
     public function __construct($config = array())
@@ -24,6 +24,7 @@ class Kwc_Root_DomainRoot_Model extends Kwf_Model_Data_Abstract
                 'id' => $key,
                 'name' => isset($val['name']) ? $val['name'] : $key,
                 'domain' => $val['domain'],
+                'preliminary_domain' => isset($val['preliminaryDomain']) ? $val['preliminaryDomain'] : null,
                 'component' => $key,
                 'pattern' => $pattern
             );
@@ -36,6 +37,9 @@ class Kwc_Root_DomainRoot_Model extends Kwf_Model_Data_Abstract
         $rows = $this->getRows();
         foreach ($rows as $row) {
             if ($row->domain == $host) {
+                return $row;
+            }
+            if ($row->preliminary_domain && $row->preliminary_domain == $host) {
                 return $row;
             }
         }

--- a/Kwf/Component/Data.php
+++ b/Kwf/Component/Data.php
@@ -206,7 +206,14 @@ class Kwf_Component_Data
      */
     public function getPreviewUrl()
     {
-        return Kwf_Setup::getBaseUrl().'/admin/component/preview/?url='.urlencode($this->getAbsoluteUrl().'?kwcPreview');
+        if ($domain = $this->getBaseProperty('preliminaryDomain')) {
+            $https = Kwf_Util_Https::domainSupportsHttps($domain);
+            $protocol = $https ? 'https' : 'http';
+            $url = $protocol . '://'.$domain.$this->url;
+        } else {
+            $url = $this->getAbsoluteUrl();
+        }
+        return Kwf_Setup::getBaseUrl().'/admin/component/preview/?url='.urlencode($url.'?kwcPreview');
     }
 
     public function __get($var)

--- a/Kwf/Util/Apc.php
+++ b/Kwf/Util/Apc.php
@@ -65,7 +65,10 @@ class Kwf_Util_Apc
                 'domain' => $d,
             )
         );
-        if ($config->server->noRedirectPattern) {
+        if ($config->server->preliminaryDomain) {
+            $domains[0]['alternative'] = $config->server->preliminaryDomain;
+        }
+        if (!isset($domains[0]['alternative']) && $config->server->noRedirectPattern) {
             $domains[0]['alternative'] = str_replace(array('^', '\\', '$'), '', $config->server->noRedirectPattern);
         }
 

--- a/Kwf/Util/Https.php
+++ b/Kwf/Util/Https.php
@@ -17,6 +17,13 @@ class Kwf_Util_Https
         if (Kwf_Config::getValue('server.https') === true) {
             if ($domains = Kwf_Config::getValueArray('server.httpsDomains')) {
                 if ($domains && !in_array($domain, $domains)) {
+                    foreach ($domains as $d) {
+                        if (substr($d, 0, 2) == '*.') {
+                            if (substr($d, 1) == substr($domain, strpos($domain, '.'))) {
+                                return true;
+                            }
+                        }
+                    }
                     return false; //current host is not in server.httpsDomains, don't use https
                 }
             }

--- a/Kwf/Util/Setup.php
+++ b/Kwf/Util/Setup.php
@@ -391,6 +391,9 @@ class Kwf_Util_Setup
                 $ret .= "    \$domainMatches = false;\n";
                 foreach ($domains as $domain) {
                     $ret .= "    if ('{$domain['domain']}' == \$host) \$domainMatches = true;\n";
+                    if (isset($domain['preliminaryDomain'])) {
+                        $ret .= "    if ('{$domain['preliminaryDomain']}' == \$host) \$domainMatches = true;\n";
+                    }
                 }
                 $ret .= "    if (!\$domainMatches) {\n";
                 foreach ($domains as $domain) {
@@ -417,12 +420,18 @@ class Kwf_Util_Setup
                 $ret .= "    }\n";
             } else if (Kwf_Config::getValue('server.domain')) {
                 $ret .= "    if (\$host != '".Kwf_Config::getValue('server.domain')."') {\n";
-                    if (Kwf_Config::getValue('server.noRedirectPattern')) {
-                        $ret .= "        if (!preg_match('/".Kwf_Config::getValue('server.noRedirectPattern')."/', \$host)) {\n";
-                        $ret .= "            \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
-                        $ret .= "        }\n";
-                    } else {
-                        $ret .= "        \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
+                    if (Kwf_Config::getValue('server.preliminaryDomain')) {
+                        $ret .= "    if (\$host != '".Kwf_Config::getValue('server.preliminaryDomain')."') {\n";
+                    }
+                        if (Kwf_Config::getValue('server.noRedirectPattern')) {
+                            $ret .= "        if (!preg_match('/".Kwf_Config::getValue('server.noRedirectPattern')."/', \$host)) {\n";
+                            $ret .= "            \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
+                            $ret .= "        }\n";
+                        } else {
+                            $ret .= "        \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
+                        }
+                    if (Kwf_Config::getValue('server.preliminaryDomain')) {
+                        $ret .= "    }\n";
                     }
                 $ret .= "    }\n";
             }

--- a/Kwf/Util/Setup.php
+++ b/Kwf/Util/Setup.php
@@ -383,6 +383,7 @@ class Kwf_Util_Setup
             $ret .= "\nif (PHP_SAPI != 'cli') Kwf_Util_SessionHandler::init();\n";
         }
 
+        $ret .= "\n\$preLogin = false;\n";
         // Falls redirectToDomain eingeschalten ist, umleiten
         if (Kwf_Config::getValue('server.redirectToDomain')) {
             $ret .= "if (\$host && substr(\$requestUri, 0, 17) != '/kwf/maintenance/' && substr(\$requestUri, 0, 8) != '/assets/') {\n";
@@ -392,7 +393,18 @@ class Kwf_Util_Setup
                 foreach ($domains as $domain) {
                     $ret .= "    if ('{$domain['domain']}' == \$host) \$domainMatches = true;\n";
                     if (isset($domain['preliminaryDomain'])) {
-                        $ret .= "    if ('{$domain['preliminaryDomain']}' == \$host) \$domainMatches = true;\n";
+                        $ret .= "    if ('{$domain['preliminaryDomain']}' == \$host) {\n";
+                        $ret .= "        \$domainMatches = true;\n";
+                        if (isset($domain['preliminaryDomainPreLogin'])) {
+                            //preliminaryDomainPreLogin set for this domain
+                            if ($domain['preliminaryDomainPreLogin']) {
+                                $ret .= "        \$preLogin = true;\n";
+                            }
+                        } else if (Kwf_Config::getValue('server.preliminaryDomainPreLogin')) {
+                            //as default use global
+                            $ret .= "        \$preLogin = true;\n";
+                        }
+                        $ret .= "    }\n";
                     }
                 }
                 $ret .= "    if (!\$domainMatches) {\n";
@@ -419,19 +431,21 @@ class Kwf_Util_Setup
                 $ret .= "        \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
                 $ret .= "    }\n";
             } else if (Kwf_Config::getValue('server.domain')) {
-                $ret .= "    if (\$host != '".Kwf_Config::getValue('server.domain')."') {\n";
-                    if (Kwf_Config::getValue('server.preliminaryDomain')) {
-                        $ret .= "    if (\$host != '".Kwf_Config::getValue('server.preliminaryDomain')."') {\n";
+                $ret .= "    if (\$host == '".Kwf_Config::getValue('server.domain')."') {\n";
+                $ret .= "        //noop\n";
+                if (Kwf_Config::getValue('server.preliminaryDomain')) {
+                    $ret .= "    } else if (\$host == '".Kwf_Config::getValue('server.preliminaryDomain')."') {\n";
+                    if (Kwf_Config::getValue('server.preliminaryDomainPreLogin')) {
+                        $ret .= "        \$preLogin = true;\n";
                     }
-                        if (Kwf_Config::getValue('server.noRedirectPattern')) {
-                            $ret .= "        if (!preg_match('/".Kwf_Config::getValue('server.noRedirectPattern')."/', \$host)) {\n";
-                            $ret .= "            \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
-                            $ret .= "        }\n";
-                        } else {
-                            $ret .= "        \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
-                        }
-                    if (Kwf_Config::getValue('server.preliminaryDomain')) {
-                        $ret .= "    }\n";
+                }
+                $ret .= "    } else {\n";
+                    if (Kwf_Config::getValue('server.noRedirectPattern')) {
+                        $ret .= "        if (!preg_match('/".Kwf_Config::getValue('server.noRedirectPattern')."/', \$host)) {\n";
+                        $ret .= "            \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
+                        $ret .= "        }\n";
+                    } else {
+                        $ret .= "        \$redirect = '".Kwf_Config::getValue('server.domain')."';\n";
                     }
                 $ret .= "    }\n";
             }
@@ -451,10 +465,16 @@ class Kwf_Util_Setup
             $ret .= "        exit;\n";
             $ret .= "    }\n";
             $ret .= "}\n";
+
         }
 
         if (Kwf_Config::getValue('preLogin')) {
             $ret .= "if (PHP_SAPI != 'cli' && Kwf_Setup::getRequestPath()!==false) {\n";
+            $ret .= "    \$preLogin = true;\n";
+            $ret .= "}\n";
+        }
+
+            $ret .= "if (\$preLogin) {\n";
             $ret .= "    \$ignore = false;\n";
             foreach (Kwf_Config::getValueArray('preLoginIgnore') as $i) {
                 $ret .= "    if (substr(\$_SERVER['REDIRECT_URL'], 0, ".strlen($i).") == '$i') \$ignore = true;\n";
@@ -481,7 +501,6 @@ class Kwf_Util_Setup
             $ret .= "        throw new Kwf_Exception_AccessDenied();\n";
             $ret .= "    }\n";
             $ret .= "}\n";
-        }
 
         if ($parameters = Kwf_Config::getValueArray('parameterToCookie')) {
             foreach($parameters as $parameter) {

--- a/config.ini
+++ b/config.ini
@@ -140,6 +140,7 @@ server.dir = false
 server.domain = false
 ; server.baseUrl =
 server.port = 22
+server.preliminaryDomainPreLogin = true
 
 server.https = unknown
 server.import.ignoreRrd = false


### PR DESCRIPTION
- used when creating preview url in admin
- allows us to set domain to the correct domain which doesn't yet point to us and use preliminaryDomain during that time
- preliminaryDomain doesn't have to match in pattern

other ideas for naming:

- interimDomain
- temporaryDomain
- provisionalDomain