### PR TITLE
Fix NULL relation error in ShowSelect

### DIFF
--- a/Kwf/Form/Field/ShowSelect.php
+++ b/Kwf/Form/Field/ShowSelect.php
@@ -36,12 +36,14 @@ class Kwf_Form_Field_ShowSelect extends Kwf_Form_Field_ShowField
         } else {
             $reference = $this->getReference();
             if ($reference) {
-                if ($referenceField = $this->getReferenceField()) {
-                    $ret[$this->getFieldName()] = $row->getParentRow($reference)->$referenceField;
-                } else {
-                    if ($row->getParentRow($reference)) {
+                if ($row->getParentRow($reference)) {
+                    if ($referenceField = $this->getReferenceField()) {
+                        $ret[$this->getFieldName()] = $row->getParentRow($reference)->$referenceField;
+                    } else {
                         $ret[$this->getFieldName()] = $row->getParentRow($reference)->__toString();
                     }
+                } else {
+                    $ret[$this->getFieldName()] = null;
                 }
             }
         }

--- a/Kwf/Form/Field/ShowSelect.php
+++ b/Kwf/Form/Field/ShowSelect.php
@@ -39,7 +39,9 @@ class Kwf_Form_Field_ShowSelect extends Kwf_Form_Field_ShowField
                 if ($referenceField = $this->getReferenceField()) {
                     $ret[$this->getFieldName()] = $row->getParentRow($reference)->$referenceField;
                 } else {
-                    $ret[$this->getFieldName()] = $row->getParentRow($reference)->__toString();
+                    if ($row->getParentRow($reference)) {
+                        $ret[$this->getFieldName()] = $row->getParentRow($reference)->__toString();
+                    }
                 }
             }
         }


### PR DESCRIPTION
If id is `NULL` with `setReference` it shows error:
```
exception 'ErrorException' with message 'Call to a member function __toString() on null' in
C:\OpenServer\domains\aviashelf\vendor\koala-framework\koala-framework\Kwf\Form\Field\
ShowSelect.php:42
```

Related to my comment:
https://github.com/koala-framework/koala-framework/issues/516#issuecomment-218375020