### PR TITLE
Implement modelProviders

### DIFF
--- a/Kwf/Model/Abstract.php
+++ b/Kwf/Model/Abstract.php
@@ -1211,76 +1211,20 @@ abstract class Kwf_Model_Abstract implements Kwf_Model_Interface
         return $this->_factoryConfig;
     }
 
-    private static function _findAllInstancesProcessModel(&$ret, $model)
-    {
-        $model = self::getInstance($model);
-        if (isset($ret[$model->getFactoryId()])) {
-            return;
-        }
-        $ret[$model->getFactoryId()] = $model;
-
-        if ($model instanceof Kwf_Model_Proxy) {
-            self::_findAllInstancesProcessModel($ret, $model->getProxyModel());
-        } else if ($model instanceof Kwf_Model_Union) {
-            foreach ($model->getUnionModels() as $subModel) {
-                self::_findAllInstancesProcessModel($ret, $subModel);
-            }
-        }
-
-        foreach ($model->getDependentModels() as $m) {
-            self::_findAllInstancesProcessModel($ret, $m);
-        }
-        foreach ($model->getSiblingModels() as $m) {
-            self::_findAllInstancesProcessModel($ret, $m);
-        }
-        foreach ($model->getReferences() as $rule) {
-            $m = $model->getReferencedModel($rule);
-            self::_findAllInstancesProcessModel($ret, $m);
-        }
-    }
-
     /**
      * Try to find all used models in the current app
      */
     public static function findAllInstances()
     {
         $ret = array();
-        foreach (glob('models/*.php') as $m) {
-            $m = str_replace('/', '_', substr($m, 7, -4));
-            $reflectionClass = new ReflectionClass($m);
-            if (!$reflectionClass->isAbstract() && is_instance_of($m, 'Kwf_Model_Interface')) {
-                self::_findAllInstancesProcessModel($ret, $m);
+        $modelProviders = Kwf_Config::getValueArray('modelProviders');
+        foreach ($modelProviders as $modelProvider) {
+            if ($modelProvider) {
+                $modelProvider = new $modelProvider;
+                $ret = array_merge($modelProvider->findModels(), $ret);
             }
         }
-
-        if (Kwf_Config::getValue('user.model')) {
-            self::_findAllInstancesProcessModel($ret, Kwf_Config::getValue('user.model'));
-        }
-
-        foreach (Kwc_Abstract::getComponentClasses() as $componentClass) {
-            $cls = strpos($componentClass, '.') ? substr($componentClass, 0, strpos($componentClass, '.')) : $componentClass;
-            $m = call_user_func(array($cls, 'createOwnModel'), $componentClass);
-            if ($m) self::_findAllInstancesProcessModel($ret, $m);
-
-            $m = call_user_func(array($cls, 'createChildModel'), $componentClass);
-            if ($m) self::_findAllInstancesProcessModel($ret, $m);
-
-            foreach (Kwc_Abstract::getSetting($componentClass, 'generators') as $g) {
-                if (isset($g['model'])) {
-                    self::_findAllInstancesProcessModel($ret, $g['model']);
-                }
-            }
-        }
-
-        foreach (Kwf_Component_Data_Root::getInstance()->getPlugins('Kwf_Component_PluginRoot_Interface_Models') as $plugin) {
-            foreach ($plugin->getModels() as $model) {
-                self::_findAllInstancesProcessModel($ret, $model);
-            }
-        }
-
-        //hardcoded models that always exist
-        self::_findAllInstancesProcessModel($ret, 'Kwf_Util_Model_Welcome');
-        self::_findAllInstancesProcessModel($ret, 'Kwf_Util_Model_Redirects');
+        $ret = array_unique($ret, SORT_REGULAR);
         return $ret;
     }
 

--- a/Kwf/Model/Provider/Abstract.php
+++ b/Kwf/Model/Provider/Abstract.php
@@ -1,0 +1,33 @@
+<?php
+abstract class Kwf_Model_Provider_Abstract
+{
+    public abstract function findModels();
+
+    protected static function _findAllInstancesProcessModel(&$ret, $model)
+    {
+        $model = Kwf_Model_Abstract::getInstance($model);
+        if (isset($ret[$model->getFactoryId()])) {
+            return;
+        }
+        $ret[$model->getFactoryId()] = $model;
+
+        if ($model instanceof Kwf_Model_Proxy) {
+            self::_findAllInstancesProcessModel($ret, $model->getProxyModel());
+        } else if ($model instanceof Kwf_Model_Union) {
+            foreach ($model->getUnionModels() as $subModel) {
+                self::_findAllInstancesProcessModel($ret, $subModel);
+            }
+        }
+
+        foreach ($model->getDependentModels() as $m) {
+            self::_findAllInstancesProcessModel($ret, $m);
+        }
+        foreach ($model->getSiblingModels() as $m) {
+            self::_findAllInstancesProcessModel($ret, $m);
+        }
+        foreach ($model->getReferences() as $rule) {
+            $m = $model->getReferencedModel($rule);
+            self::_findAllInstancesProcessModel($ret, $m);
+        }
+    }
+}

--- a/Kwf/Model/Provider/ClassNames.php
+++ b/Kwf/Model/Provider/ClassNames.php
@@ -1,0 +1,14 @@
+<?php
+abstract class Kwf_Model_Provider_ClassNames extends Kwf_Model_Provider_Abstract
+{
+    protected $_modelClasses;
+
+    public function findModels()
+    {
+        $ret = array();
+        foreach ($this->_modelClasses as $modelClass) {
+            self::_findAllInstancesProcessModel($ret, $modelClass);
+        }
+        return $ret;
+    }
+}

--- a/Kwf/Model/Provider/Components.php
+++ b/Kwf/Model/Provider/Components.php
@@ -1,0 +1,29 @@
+<?php
+class Kwf_Model_Provider_Components extends Kwf_Model_Provider_Abstract
+{
+    public function findModels()
+    {
+        $ret = array();
+        foreach (Kwc_Abstract::getComponentClasses() as $componentClass) {
+            $cls = strpos($componentClass, '.') ? substr($componentClass, 0, strpos($componentClass, '.')) : $componentClass;
+            $m = call_user_func(array($cls, 'createOwnModel'), $componentClass);
+            if ($m) self::_findAllInstancesProcessModel($ret, $m);
+
+            $m = call_user_func(array($cls, 'createChildModel'), $componentClass);
+            if ($m) self::_findAllInstancesProcessModel($ret, $m);
+
+            foreach (Kwc_Abstract::getSetting($componentClass, 'generators') as $g) {
+                if (isset($g['model'])) {
+                    self::_findAllInstancesProcessModel($ret, $g['model']);
+                }
+            }
+        }
+
+        foreach (Kwf_Component_Data_Root::getInstance()->getPlugins('Kwf_Component_PluginRoot_Interface_Models') as $plugin) {
+            foreach ($plugin->getModels() as $model) {
+                self::_findAllInstancesProcessModel($ret, $model);
+            }
+        }
+        return $ret;
+    }
+}

--- a/Kwf/Model/Provider/Default.php
+++ b/Kwf/Model/Provider/Default.php
@@ -1,0 +1,25 @@
+<?php
+class Kwf_Model_Provider_Default extends Kwf_Model_Provider_Abstract
+{
+    public function findModels()
+    {
+        $ret = array();
+        foreach (glob('models/*.php') as $m) {
+            $m = str_replace('/', '_', substr($m, 7, -4));
+            $reflectionClass = new ReflectionClass($m);
+            if (!$reflectionClass->isAbstract() && is_instance_of($m, 'Kwf_Model_Interface')) {
+                self::_findAllInstancesProcessModel($ret, $m);
+            }
+        }
+
+        if (Kwf_Config::getValue('user.model')) {
+            self::_findAllInstancesProcessModel($ret, Kwf_Config::getValue('user.model'));
+        }
+
+        //hardcoded models that always exist
+        self::_findAllInstancesProcessModel($ret, 'Kwf_Util_Model_Welcome');
+        self::_findAllInstancesProcessModel($ret, 'Kwf_Util_Model_Redirects');
+
+        return $ret;
+    }
+}

--- a/config.ini
+++ b/config.ini
@@ -193,6 +193,10 @@ server.updateTags[] = pages
 ; updateDownloader.kwf.github.user = vivid-planet
 ; updateDownloader.kwf.github.repository = koala-framework
 
+modelProviders.default = Kwf_Model_Provider_Default
+modelProviders.components = Kwf_Model_Provider_Components
+
+
 [test : production]
 debug.error.log = false
 preLogin = true


### PR DESCRIPTION
This feature is required for packages to support update-scripts for
models not connected to any component.
Code to find models moved to corresponding model-provider.
Helper function to find relation-models moved into modelProviderAbstract