### PR TITLE
Convert kwf_update table to kwf_updates containing a row per update

### DIFF
--- a/Kwf/Controller/Action/Cli/Web/SetupController.php
+++ b/Kwf/Controller/Action/Cli/Web/SetupController.php
@@ -39,8 +39,8 @@ class Kwf_Controller_Action_Cli_Web_SetupController extends Kwf_Controller_Actio
         } catch (Exception $e) {
             throw new Kwf_Exception_Client("Fetching Tables failed: ".$e->getMessage());
         }
-        if (in_array('kwf_update', $tables)) {
-            echo "Application seems to be set up already. (kwf_update table exists)\n";
+        if (in_array('kwf_update', $tables) || in_array('kwf_updates', $tables)) {
+            echo "Application seems to be set up already. (kwf_updates table exists)\n";
             echo "Executing update...\n";
             $this->forward('index', 'update');
             return;

--- a/Kwf/Controller/Action/Cli/Web/UpdateController.php
+++ b/Kwf/Controller/Action/Cli/Web/UpdateController.php
@@ -98,8 +98,7 @@ class Kwf_Controller_Action_Cli_Web_UpdateController extends Kwf_Controller_Acti
         } else {
             $executedUpdates = $runner->executeUpdates();
             echo "\n\033[32mupdate finished\033[0m\n";
-            $doneNames = array_unique(array_merge($doneNames, $executedUpdates));
-            $runner->writeExecutedUpdates($doneNames);
+            $runner->writeExecutedUpdates($executedUpdates);
         }
         
         if (!$this->_getParam('debug')) Kwf_Util_Maintenance::restoreMaintenanceBootstrap();

--- a/Kwf/Controller/Action/Maintenance/SetupController.php
+++ b/Kwf/Controller/Action/Maintenance/SetupController.php
@@ -37,7 +37,7 @@ class Kwf_Controller_Action_Maintenance_SetupController extends Kwf_Controller_A
             } catch (Exception $e) {
                 throw new Kwf_Exception_Client("Fetching Tables failed: ".$e->getMessage());
             }
-            if (in_array('kwf_update', $tables)) {
+            if (in_array('kwf_update', $tables) || in_array('kwf_updates', $tables)) {
                 throw new Kwf_Exception_Client("Application seems to be set up already. (kwf_update table exists)");
             }
             if ($tables) {

--- a/Kwf/Controller/Action/Maintenance/UpdateController.php
+++ b/Kwf/Controller/Action/Maintenance/UpdateController.php
@@ -67,8 +67,8 @@ class Kwf_Controller_Action_Maintenance_UpdateController extends Kwf_Controller_
         if (!$runner->checkUpdatesSettings()) {
             throw new Kwf_Exception_Client("checkSettings failed, update stopped");
         }
-        $doneNames = array_merge($doneNames, $runner->executeUpdates());
-        $runner->writeExecutedUpdates($doneNames);
+        $executedUpdates = $runner->executeUpdates();
+        $runner->writeExecutedUpdates($executedUpdates);
 
         $errMsg = '';
         $errors = $runner->getErrors();

--- a/Kwf/Update/20150309Legacy38004.sql
+++ b/Kwf/Update/20150309Legacy38004.sql
@@ -1,4 +1,0 @@
-CREATE TABLE  `kwf_update` (
-    `data` TEXT CHARACTER SET utf8 COLLATE utf8_bin NOT NULL
-) ENGINE = INNODB;
-INSERT INTO  `kwf_update` (`data`) VALUES ('');

--- a/Kwf/Update/20160715KwfUpdates.php
+++ b/Kwf/Update/20160715KwfUpdates.php
@@ -1,0 +1,31 @@
+<?php
+class Kwf_Update_20160715KwfUpdates extends Kwf_Update
+{
+    public function update()
+    {
+        $db = Kwf_Registry::get('db');
+
+        $doneNames = Kwf_Util_Update_Helper::getExecutedUpdatesNames();
+
+        $db->query("CREATE TABLE `kwf_updates` (
+            `id` int(11) NOT NULL,
+            `name` varchar(255) NOT NULL,
+            `executed_at` datetime DEFAULT NULL,
+            `log` TEXT NOT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;");
+
+        $db->query("ALTER TABLE `kwf_updates`
+            ADD PRIMARY KEY (`id`);");
+
+        $db->query("ALTER TABLE `kwf_updates`
+            MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;");
+
+        foreach ($doneNames as $name) {
+            $db->query("INSERT INTO kwf_updates SET name=?, executed_at=NOW()", $name);
+        }
+
+        if (in_array('kwf_update', $db->listTables())) {
+            $db->query("RENAME TABLE `kwf_update` TO `kwf_update_backup`");
+        }
+    }
+}

--- a/Kwf/Util/Update/Runner.php
+++ b/Kwf/Util/Update/Runner.php
@@ -66,10 +66,12 @@ class Kwf_Util_Update_Runner
 
     public function writeExecutedUpdates($doneNames)
     {
-        Kwf_Registry::get('db')->query("UPDATE kwf_update SET data=?", serialize($doneNames));
-        if (file_exists('update')) {
-            //move away old update file to avoid confusion
-            rename('update', 'update.backup');
+        $m = Kwf_Model_Abstract::getInstance('Kwf_Util_Update_UpdatesModel');
+        foreach ($doneNames as $name) {
+            $row = $m->createRow();
+            $row->name = $name;
+            $row->executed_at = date('Y-m-d H:i:s');
+            $row->save();
         }
     }
 

--- a/Kwf/Util/Update/UpdatesModel.php
+++ b/Kwf/Util/Update/UpdatesModel.php
@@ -1,0 +1,5 @@
+<?php
+class Kwf_Util_Update_UpdatesModel extends Kwf_Model_Db
+{
+    protected $_table = 'kwf_updates';
+}


### PR DESCRIPTION
- much nicher to check executed updates
- fixes possible issue when serialized string is larger than mysql max_allowed_packet
  Default max_allowed_packet is 1MB which can be reached with larger webs