### PR TITLE
Responsive Image: less steps in widths

### DIFF
--- a/Kwc/Abstract/Image/Component.twig
+++ b/Kwc/Abstract/Image/Component.twig
@@ -3,8 +3,7 @@
         {% block image %}
         <{% if inlineTags %}span{% else %}div{% endif %} class="{{ "outerContainer"|bemClass }}">
             <{% if inlineTags %}span{% else %}div{% endif %} class="{{ containerClass }}" style="padding-bottom: {{aspectRatio}}%"
-                data-min-width="{{ minWidth }}"
-                data-max-width="{{ maxWidth }}"
+                data-width-steps="{{ widthSteps|json_encode }}"
                 data-src="{{ baseUrl }}">
                 {% if outputImgTag %}
                 <noscript>

--- a/Kwc/Basic/ImageEnlarge/Component.tpl
+++ b/Kwc/Basic/ImageEnlarge/Component.tpl
@@ -2,8 +2,7 @@
 <?php if ($this->baseUrl) { ?>
     <?=$this->component($this->linkTag)?>
     <div class="<?=$this->containerClass?>" style="padding-bottom:<?=$this->aspectRatio?>%;"
-            data-min-width="<?=$this->minWidth;?>"
-            data-max-width="<?=$this->maxWidth;?>"
+            data-width-steps="{{ json_encode($this->widthSteps) }}"
             data-src="<?=$this->baseUrl;?>">
         <noscript>
             <?=$this->image($this->image, $this->altText, $this->imgAttributes)?>

--- a/Kwc/Basic/ImageEnlarge/EnlargeTag/ImagePage/Component.tpl
+++ b/Kwc/Basic/ImageEnlarge/EnlargeTag/ImagePage/Component.tpl
@@ -20,8 +20,7 @@
         <?php if ($this->baseUrl) { ?>
         <div class="kwfUp-image" style="max-width:<?=$this->width;?>px;">
             <div class="kwfUp-container" style="padding-bottom:<?=$this->aspectRatio;?>%;"
-                    data-min-width="<?=$this->minWidth;?>"
-                    data-max-width="<?=$this->maxWidth;?>"
+                    data-width-steps="{{ json_encode($this->widthSteps) }}"
                     data-src="<?=$this->baseUrl;?>">
                 <noscript>
                     <img class="kwfUp-centerImage kwfUp-hideWhileLoading" src="<?=$this->imageUrl?>" width="<?=$this->width?>" height="<?=$this->height?>" alt="" />

--- a/Kwf/Media/Image.php
+++ b/Kwf/Media/Image.php
@@ -14,6 +14,16 @@ class Kwf_Media_Image
         return end($widths);
     }
 
+    //formular that increases the offset between two width steps based on the width
+    //1000: ~100
+    //2000: ~200
+    //3000: ~400
+    //4000: ~700
+    private static function _getOffsetAtWidth($width)
+    {
+        return floor(pow($width/300, 2.5)+100);
+    }
+
     /**
      * Returns supported image-widths of specific image with given base-dimensions
      */
@@ -45,15 +55,24 @@ class Kwf_Media_Image
             $calculateWidth = $imageDimensions['width'];
         }
 
-        $width = $calculateWidth % 100; // startwidth or minwidth
-        if ($width == 0) $width = 100;
+        $width = $calculateWidth;
         do {
             $ret[] = $width;
-            $width += 100;
-        } while ($width < $maxWidth);
-        if ($width - 100 != $maxWidth) {
-            $ret[] = $maxWidth;
+            $width -= self::_getOffsetAtWidth($width);
+        } while ($width > 0);
+
+
+        $width = $calculateWidth;
+        while (true) {
+            $width += self::_getOffsetAtWidth($width);
+            if ($width >= $maxWidth) {
+                break;
+            }
+            $ret[] = $width;
         }
+        $ret[] = $maxWidth;
+        sort($ret);
+
         return $ret;
     }
 

--- a/Kwf/Media/Output/Component.php
+++ b/Kwf/Media/Output/Component.php
@@ -14,9 +14,7 @@ class Kwf_Media_Output_Component
         if (isset($dimensions['width']) && $dimensions['width'] > 0) {
             $aspectRatio = $dimensions['height'] / $dimensions['width'] * 100;
             $width = $dimensions['width'];
-            $steps = Kwf_Media_Image::getResponsiveWidthSteps($dimensions, $imageFile);
-            $ret['minWidth'] = $steps[0];
-            $ret['maxWidth'] = end($steps);
+            $ret['widthSteps'] = Kwf_Media_Image::getResponsiveWidthSteps($dimensions, $imageFile);
         }
         $ret['width'] = $width;
         $ret['aspectRatio'] = $aspectRatio;

--- a/commonjs/responsive-img.js
+++ b/commonjs/responsive-img.js
@@ -48,28 +48,13 @@ $(function() {
 });
 
 
-function getResponsiveWidthStep(width,  minWidth, maxWidth) {
-    var steps = getResponsiveWidthSteps(minWidth, maxWidth);
-    for (var i = 0; i < steps.length; i++) {
-        if (width <= steps[i]) {
-            return steps[i];
+function getResponsiveWidthStep(width,  widthSteps) {
+    for (var i = 0; i < widthSteps.length; i++) {
+        if (width <= widthSteps[i]) {
+            return widthSteps[i];
         }
     }
-    return steps[steps.length-1];
-};
-
-// Has similar algorithm in Kwf_Media_Image
-function getResponsiveWidthSteps(minWidth, maxWidth) {
-    var width = minWidth; // startwidth or minwidth
-    var steps = [];
-    do {
-        steps.push(width);
-        width += 100;
-    } while (width < maxWidth);
-    if (width - 100 != maxWidth) {
-        steps.push(maxWidth);
-    }
-    return steps;
+    return widthSteps[steps.length-1];
 };
 
 function initResponsiveImgEl(el) {
@@ -81,15 +66,10 @@ function initResponsiveImgEl(el) {
     el[0].responsiveImgInitDone = true; //don't save as el.data to avoid getting it copied when cloning elements
     var devicePixelRatio = window.devicePixelRatio ? window.devicePixelRatio : 1;
     var baseUrl = el.data("src");
-    var minWidth = parseInt(el.data("minWidth"));
-    var maxWidth = parseInt(el.data("maxWidth"));
 
     el.data('baseUrl', baseUrl);
-    el.data('minWidth', minWidth);
-    el.data('maxWidth', maxWidth);
 
-    var width = getResponsiveWidthStep(
-            elWidth * devicePixelRatio, minWidth, maxWidth);
+    var width = getResponsiveWidthStep(elWidth * devicePixelRatio, el.data("widthSteps"));
     el.data('loadedWidth', width);
     var sizePath = baseUrl.replace(DONT_HASH_TYPE_PREFIX+'{width}',
             DONT_HASH_TYPE_PREFIX+width);
@@ -117,8 +97,7 @@ function checkResponsiveImgEl(responsiveImgEl) {
     var elWidth = getCachedWidth(responsiveImgEl);
     if (elWidth == 0) return;
     var devicePixelRatio = window.devicePixelRatio ? window.devicePixelRatio : 1;
-    var width = getResponsiveWidthStep(elWidth * devicePixelRatio,
-            responsiveImgEl.data('minWidth'), responsiveImgEl.data('maxWidth'));
+    var width = getResponsiveWidthStep(elWidth * devicePixelRatio, responsiveImgEl.data("widthSteps"));
     if (width > responsiveImgEl.data('loadedWidth')) {
         responsiveImgEl.data('loadedWidth', width);
         var sizePath = responsiveImgEl.data('baseUrl').replace(DONT_HASH_TYPE_PREFIX+'{width}',


### PR DESCRIPTION
Instead of 100px steps increase step size based on width:
- 1000: ~100
- 2000: ~200
- 3000: ~400
- 4000: ~700

This results in:
7680 width: 24 instead of 76 different sizes
3600 width: 21 instead of 36 different sizes