### PR TITLE
Fix duplicated imagetags

### DIFF
--- a/commonjs/responsive-img.js
+++ b/commonjs/responsive-img.js
@@ -15,6 +15,9 @@ module.exports = function (selector) {
         } else {
             if (el.hasClass('kwfUp-loadImmediately') || isElementInView(el)) {
                 initResponsiveImgEl(el);
+                if (deferredImages.indexOf(el) != -1) {
+                    deferredImages.splice(deferredImages.indexOf(el), 1);
+                }
             } else {
                 if (!el.data('responsiveImgInitDeferred')) {
                     deferredImages.push(el);
@@ -40,7 +43,9 @@ $(function() {
             if (isElementInView(el)) {
                 deferredImages.splice(i, 1);
                 i--;
-                initResponsiveImgEl(el);
+                if (!el[0].responsiveImgInitDone) {
+                    initResponsiveImgEl(el);
+                }
             }
         }
     }


### PR DESCRIPTION
If an element comes into view without scrolling, for example in a slider, it has to be removed from deferedImages array.
Because orientationchange triggers a scrollevent on some devices, a check has to be made if the element is not already initialized in the showImageWhenVisible function.