### PR TITLE
Add config setting to disable checking db connection in /kwf/check

### DIFF
--- a/Kwf/Util/Check.php
+++ b/Kwf/Util/Check.php
@@ -5,7 +5,7 @@ class Kwf_Util_Check
     {
         $ok = true;
         $msg = '';
-        if (Kwf_Setup::hasDb()) {
+        if (Kwf_Config::getValue('kwfCheck.checkDbConnection') && Kwf_Setup::hasDb()) {
             $date = Kwf_Registry::get('db')->query("SELECT NOW()")->fetchColumn();
             if (!$date) {
                 $ok = false;

--- a/config.ini
+++ b/config.ini
@@ -30,6 +30,7 @@ isOnline = true
 preLogin = false
 whileUpdatingShowMaintenancePage = true
 clearCacheClass = Kwf_Util_ClearCache
+kwfCheck.checkDbConnection = true
 money.format = "EUR {0}"
 money.decimals = 2
 frontControllerClass = false


### PR DESCRIPTION
Useful for a check which just checks if webserver is running and not dependent services.

Alternatively this clould be removed completely - why check mysql but not memcache, solr etc...