### PR TITLE
Major change to Mail Redirects making it possible to show a webversion of newsletter in browser

### DIFF
--- a/Kwc/Basic/LinkTag/Abstract/Mail.html.tpl
+++ b/Kwc/Basic/LinkTag/Abstract/Mail.html.tpl
@@ -1,6 +1,6 @@
 <?php
 if ($this->data->url) {
-    echo '<a href="*redirect*' . htmlspecialchars($this->data->url) . '*">';
+    echo '<a href="' . htmlspecialchars($this->data->url) . '">';
 } else {
     echo '<a>'; // hack, see commit message
 }

--- a/Kwc/Basic/LinkTag/Abstract/Mail.txt.tpl
+++ b/Kwc/Basic/LinkTag/Abstract/Mail.txt.tpl
@@ -1,4 +1,4 @@
 <?php
 if ($this->data->url) {
-    echo '*redirect*'.$this->data->url.'*';
+    echo $this->data->getAbsoluteUrl();
 }

--- a/Kwc/Guestbook/ActivatePost/Component.php
+++ b/Kwc/Guestbook/ActivatePost/Component.php
@@ -8,6 +8,8 @@ class Kwc_Guestbook_ActivatePost_Component extends Kwc_Form_Success_Component
         $ret = parent::getSettings($param);
         $ret['placeholder']['success'] = trlKwfStatic('The entry in your guestbook has been acitvated.');
         $ret['placeholder']['toGuestbook'] = trlKwfStatic('Use this link to get to your guestbook:');
+        $ret['flags']['processInput'] = true;
+        $ret['flags']['passMailRecipient'] = true;
         return $ret;
     }
 
@@ -18,14 +20,22 @@ class Kwc_Guestbook_ActivatePost_Component extends Kwc_Form_Success_Component
         return $ret;
     }
 
-
-    public function processMailRedirectInput($recipient, $params)
+    public function processInput(array $postData)
     {
-        $model = $this->getData()->parent->getComponent()->getChildModel();
-        if (!empty($params['post_id']) && is_numeric($params['post_id'])) {
-            $postRow = $model->getRow($params['post_id']);
+        if (!isset($postData['recipient']) || !isset($postData['post_id'])) {
+            throw new Kwf_Exception_NotFound();
         }
-        if (!isset($postRow)) {
+        $recipient = Kwc_Mail_Redirect_Component::parseRecipientParam($postData['recipient']); //do nothing with recipient, just make sure it is a valid one
+
+        $post = explode('.', $postData['post_id']);
+        $postId = $post[0];
+        if (Kwf_Util_Hash::hash($postId) != $post[1]) {
+            throw new Kwf_Exception_AccessDenied();
+        }
+
+        $model = $this->getData()->parent->getComponent()->getChildModel();
+        $postRow = $model->getRow($postId);
+        if (!$postRow) {
             throw new Kwf_ClientException(trlKwf("This post does not exist anymore."));
         }
 

--- a/Kwc/Guestbook/Mail/Mail.txt.tpl
+++ b/Kwc/Guestbook/Mail/Mail.txt.tpl
@@ -13,10 +13,10 @@
 
 <?php if ($this->activationType == Kwc_Guestbook_Component::INACTIVE_ON_SAVE) {
     echo $this->data->trlKwf('Click this link to activate the post on your website:');
-    echo "\n*showcomponent*".$this->activateId."*&post_id=".$this->activatePostId;
+    echo "\n".$this->activateComponent->getAbsoluteUrl()."?post_id=".$this->activatePostId;
 } else if ($this->activationType == Kwc_Guestbook_Component::ACTIVE_ON_SAVE) {
     echo $this->data->trlKwf('If you wish to deactivate the post in your guestbook, click here:');
-    echo "\n*showcomponent*".$this->activateId."*&post_id=".$this->activatePostId;
+    echo "\n".$this->activateComponent->getAbsoluteUrl()."?post_id=".$this->activatePostId;
 } ?>
 
 

--- a/Kwc/Guestbook/Write/Form/Component.php
+++ b/Kwc/Guestbook/Write/Form/Component.php
@@ -42,8 +42,8 @@ class Kwc_Guestbook_Write_Form_Component extends Kwc_Posts_Write_Form_Component
                         'email' => $row->email,
                         'url'   => $guestbookComponent->getAbsoluteUrl(),
                         'text'  => $row->content,
-                        'activateId' => $guestbookComponent->getChildComponent("-$activationChildId")->componentId,
-                        'activatePostId' => $row->id,
+                        'activateComponent' => $guestbookComponent->getChildComponent("-$activationChildId"),
+                        'activatePostId' => $row->id.'.'.Kwf_Util_Hash::hash($row->id),
                         'activationType' => $settingsRow->post_activation_type
                     ),
                     null,

--- a/Kwc/Mail/PlaceholdersPlugin.php
+++ b/Kwc/Mail/PlaceholdersPlugin.php
@@ -1,6 +1,7 @@
 <?php
 class Kwc_Mail_PlaceholdersPlugin extends Kwf_Component_Plugin_Placeholders
 {
+    //called by Kwc_Mail_Abstract_Component::getHtml and getText
     public function processMailOutput($output, Kwc_Mail_Recipient_Interface $recipient = null)
     {
         $placeholders = Kwf_Component_Data_Root::getInstance()
@@ -8,6 +9,22 @@ class Kwc_Mail_PlaceholdersPlugin extends Kwf_Component_Plugin_Placeholders
             ->getComponent()->getPlaceholders($recipient);
         foreach ($placeholders as $p=>$v) {
             $output = str_replace("%$p%", $v, $output);
+        }
+        return $output;
+    }
+
+    //called during rendering as view plugin
+    //recipient is set when showing mail in browser, not when sending mail
+    public function processOutput($output, $renderer)
+    {
+        $output = parent::processOutput($output, $renderer);
+
+        $c = Kwf_Component_Data_Root::getInstance()->getComponentById($this->_componentId);
+        $recipient = $c->getComponent()->getRecipient();
+        $redirectComponent = $c->getChildComponent('_redirect');
+        if ($redirectComponent && $recipient) {
+            $redirectComponent = $redirectComponent->getComponent();
+            $output = $redirectComponent->replaceLinks($output, $recipient, 'html');
         }
         return $output;
     }

--- a/Kwc/Mail/Redirect/ContentSender.php
+++ b/Kwc/Mail/Redirect/ContentSender.php
@@ -6,19 +6,8 @@ class Kwc_Mail_Redirect_ContentSender extends Kwf_Component_Abstract_ContentSend
         $process = $this->_getProcessInputComponents($includeMaster);
         self::_callProcessInput($process);
 
-        $r = $this->_data->getComponent()->getRedirectRow();
-
-        // if it is of type redirect, do the redirect
-        if ($r->type == 'redirect') {
-            header('Location: '.$r->value);
-        } else if ($r->type == 'showcomponent') {
-            $c = Kwf_Component_Data_Root::getInstance()
-                ->getComponentById($r->value);
-            $cs = Kwc_Abstract::getSetting($c->componentClass, 'contentSender');
-            $cs = new $cs($c);
-            $cs->sendContent($includeMaster);
-        }
-
+        $r = $this->_data->getComponent()->getRedirectUrl();
+        header('Location: '.$r);
         self::_callPostProcessInput($process);
     }
 }

--- a/Kwc/Mail/Redirect/Update/20150309Legacy30442.sql
+++ b/Kwc/Mail/Redirect/Update/20150309Legacy30442.sql
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS `kwc_mail_redirect` (
   `id` int(10) unsigned NOT NULL auto_increment,
-  `value` varchar(255) NOT NULL,
-  `type` varchar(255) NOT NULL,
+  `value` varchar(255) NOT NULL
   PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB;
 ALTER TABLE `kwc_mail_redirect` ADD INDEX ( `value` );

--- a/Kwc/Mail/Redirect/Update/20150309Legacy30443.sql
+++ b/Kwc/Mail/Redirect/Update/20150309Legacy30443.sql
@@ -1,1 +1,0 @@
-ALTER TABLE  `kwc_mail_redirect` ADD  `title` VARCHAR( 255 ) NOT NULL;

--- a/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/EditSubscriber/Mail.html.tpl
+++ b/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/EditSubscriber/Mail.html.tpl
@@ -1,4 +1,2 @@
 <?php
-if ($this->data->url) {
-    echo '<a href="*showcomponent*' . $this->editSubscriber->componentId . '*">';
-}
+echo $this->componentLink($this->editSubscriber);

--- a/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/EditSubscriber/Mail.txt.tpl
+++ b/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/EditSubscriber/Mail.txt.tpl
@@ -1,4 +1,2 @@
 <?php
-if ($this->data->url) {
-    echo '*showcomponent*'.$this->editSubscriber->componentId.'*';
-}
+echo $this->editSubscriber->getAbsoluteUrl();

--- a/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/Unsubscribe/Mail.html.tpl
+++ b/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/Unsubscribe/Mail.html.tpl
@@ -1,4 +1,2 @@
 <?php
-if ($this->data->url) {
-    echo '<a href="*showcomponent*' . $this->unsubscribe->componentId . '*">';
-}
+echo $this->componentLink($this->unsubscribe);

--- a/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/Unsubscribe/Mail.txt.tpl
+++ b/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/Unsubscribe/Mail.txt.tpl
@@ -1,4 +1,2 @@
 <?php
-if ($this->data->url) {
-    echo '*showcomponent*'.$this->unsubscribe->componentId.'*';
-}
+echo $this->unsubscribe->getAbsoluteUrl();

--- a/Kwc/Newsletter/Detail/StatisticsController.php
+++ b/Kwc/Newsletter/Detail/StatisticsController.php
@@ -10,7 +10,6 @@ class Kwc_Newsletter_Detail_StatisticsController extends Kwf_Controller_Action_A
 
         $this->_columns->add(new Kwf_Grid_Column('pos'));
         $this->_columns->add(new Kwf_Grid_Column('link', trlKwf('Link'), 600));
-        $this->_columns->add(new Kwf_Grid_Column('title', trlKwf('Title'), 200));
         $this->_columns->add(new Kwf_Grid_Column('count', trlKwf('Count'), 50))
             ->setCssClass('kwf-renderer-decimal');
         $this->_columns->add(new Kwf_Grid_Column('percent', trlKwf('[%]'), 50));
@@ -48,7 +47,6 @@ class Kwc_Newsletter_Detail_StatisticsController extends Kwf_Controller_Action_A
                 $ret[] = array(
                     'pos' => $pos++,
                     'link' => trlKwf('view rate') . ' (' . trlKwf('percentage of users which opened the html newsletter') . ')',
-                    'title' => '',
                     'count' => $count,
                     'percent' => number_format(($count / $total)*100, 2) . '%'
                 );
@@ -59,43 +57,28 @@ class Kwc_Newsletter_Detail_StatisticsController extends Kwf_Controller_Action_A
         $ret[] = array(
             'pos' => $pos++,
             'link' => trlKwf('click rate') . ' (' . trlKwf('percentage of users which clicked at least one link in newsletter') . ')',
-            'title' => '',
             'count' => $count,
             'percent' => number_format(($count / $total)*100, 2) . '%'
         );
         $ret[] = array(
             'pos' => $pos++,
             'link' => ' ',
-            'title' => '',
             'count' => '',
             'percent' => '',
         );
         $sql = "
-            SELECT r.value, r.type, r.title, count(distinct(concat(s.recipient_id,s.recipient_model_shortcut))) c
+            SELECT r.value, count(distinct(concat(s.recipient_id,s.recipient_model_shortcut))) c
             FROM kwc_mail_redirect_statistics s, kwc_mail_redirect r
             WHERE s.redirect_id=r.id AND mail_component_id=?
             GROUP BY redirect_id
             ORDER BY c DESC
         ";
         foreach ($db->fetchAll($sql, $newsletterComponent->componentId) as $row) {
-            if ($row['type'] == 'showcomponent') {
-                $c = Kwf_Component_Data_Root::getInstance()->getComponentById($row['value']);
-                if ($c) {
-                    $link =
-                        'http://' . Kwf_Registry::get('config')->server->domain .
-                        $c->getUrl() .
-                        ' (' . substr(strrchr($row['value'], '-'), 1) . ')';
-                } else {
-                    $link = $row['value'];
-                }
-            } else {
-                $link = $row['value'];
-            }
+            $link = $row['value'];
             $row['value'] = $link;
             $ret[] = array(
                 'pos' => $pos++,
                 'link' => $link,
-                'title' => $row['title'],
                 'count' => $row['c'],
                 'percent' => number_format(($row['c'] / $total)*100, 2) . '%'
             );

--- a/Kwc/Newsletter/EditSubscriber/Component.php
+++ b/Kwc/Newsletter/EditSubscriber/Component.php
@@ -12,12 +12,17 @@ class Kwc_Newsletter_EditSubscriber_Component extends Kwc_Form_Component
         $ret['viewCache'] = false;
         $ret['flags']['skipFulltext'] = true;
         $ret['flags']['noIndex'] = true;
+        $ret['flags']['processInput'] = true;
+        $ret['flags']['passMailRecipient'] = true;
         return $ret;
     }
 
-    public function processMailRedirectInput($recipient, $params)
+    public function processInput(array $postData)
     {
-        $this->_recipient = $recipient;
+        if (!isset($postData['recipient'])) {
+            throw new Kwf_Exception_NotFound();
+        }
+        $this->_recipient = Kwc_Mail_Redirect_Component::parseRecipientParam($postData['recipient']);
         $this->processInput($params);
     }
 

--- a/Kwc/Newsletter/Subscribe/Component.php
+++ b/Kwc/Newsletter/Subscribe/Component.php
@@ -16,7 +16,11 @@ class Kwc_Newsletter_Subscribe_Component extends Kwc_Form_Component
         $ret['subscribeType'] = self::CONFIRM_MAIL_ONLY;
 
         $ret['generators']['child']['component']['mail'] = 'Kwc_Newsletter_Subscribe_Mail_Component';
-        $ret['generators']['child']['component']['doubleOptIn'] = 'Kwc_Newsletter_Subscribe_DoubleOptIn_Component';
+        $ret['generators']['doubleOptIn'] = array(
+            'class' => 'Kwf_Component_Generator_Page_Static',
+            'component' => 'Kwc_Newsletter_Subscribe_DoubleOptIn_Component',
+            'name' => trlKwfStatic('Opt In')
+        );
 
         $ret['from'] = ''; // would be good if overwritten
 
@@ -109,22 +113,22 @@ class Kwc_Newsletter_Subscribe_Component extends Kwc_Form_Component
         }
 
         $nlData = $this->getSubscribeToNewsletterComponent();
-        $editComponentId = $nlData->getChildComponent('_editSubscriber')->componentId;
-        $unsubscribeComponentId = null;
-        $doubleOptInComponentId = null;
+        $editComponent = $nlData->getChildComponent('_editSubscriber');
+        $unsubscribeComponent = null;
+        $doubleOptInComponent = null;
         if ($this->_getSetting('subscribeType') == self::DOUBLE_OPT_IN) {
-            $doubleOptInComponentId = $this->getData()->getChildComponent('-doubleOptIn')->componentId;
+            $doubleOptInComponent = $this->getData()->getChildComponent('_doubleOptIn');
         } else {
-            $unsubscribeComponentId = $nlData->getChildComponent('_unsubscribe')->componentId;
+            $unsubscribeComponent = $nlData->getChildComponent('_unsubscribe');
         }
 
         $mail = $this->getData()->getChildComponent('-mail')->getComponent();
         $mail->send($row, array(
             'formRow' => $row,
             'host' => $host,
-            'unsubscribeComponentId' => $unsubscribeComponentId,
-            'editComponentId' => $editComponentId,
-            'doubleOptInComponentId' => $doubleOptInComponentId
+            'unsubscribeComponent' => $unsubscribeComponent,
+            'editComponent' => $editComponent,
+            'doubleOptInComponent' => $doubleOptInComponent
         ));
     }
 

--- a/Kwc/Newsletter/Subscribe/DoubleOptIn/Component.php
+++ b/Kwc/Newsletter/Subscribe/DoubleOptIn/Component.php
@@ -5,11 +5,18 @@ class Kwc_Newsletter_Subscribe_DoubleOptIn_Component extends Kwc_Form_Success_Co
     {
         $ret = parent::getSettings($param);
         $ret['placeholder']['success'] = trlKwfStatic('Your E-Mail address has been verified. You will receive our newsletters in future.');
+        $ret['flags']['processInput'] = true;
+        $ret['flags']['passMailRecipient'] = true;
         return $ret;
     }
 
-    public function processMailRedirectInput($recipient, $params)
+    public function processInput(array $postData)
     {
+        if (!isset($postData['recipient'])) {
+            throw new Kwf_Exception_NotFound();
+        }
+        $recipient = Kwc_Mail_Redirect_Component::parseRecipientParam($postData['recipient']);
+
         $recipient->unsubscribed = 0;
         $recipient->activated = 1;
         $recipient->save();

--- a/Kwc/Newsletter/Subscribe/Mail/Mail.html.tpl
+++ b/Kwc/Newsletter/Subscribe/Mail/Mail.html.tpl
@@ -4,13 +4,13 @@
 
 <?php if ($this->doubleOptInComponentId) { ?>
     <?= '-- '.$this->data->trlKwf('ACTIVATION LINK').' --'; ?><br />
-    <a href="*showcomponent*<?= $this->doubleOptInComponentId; ?>*"><?= $this->data->trlKwf('Please click here, to confirm your E-Mail address and to receive our newsletters in future.'); ?></a><br /><br />
+    <?=$this->componentLink($this->doubleOptInComponent, $this->data->trlKwf('Please click here, to confirm your E-Mail address and to receive our newsletters in future.')); ?><br /><br />
 <?php } else if ($this->unsubscribeComponentId) { ?>
     <?= $this->data->trlKwf('To unsubscribe anytime from our newsletter, click this link:'); ?><br />
-    <a href="*showcomponent*<?= $this->unsubscribeComponentId; ?>*"><?= $this->data->trlKwf('Unsubscribe'); ?></a><br /><br />
+<?=$this->componentLink($this->unsubscribeComponent, $this->data->trlKwf('Unsubscribe')); ?><br /><br />
 <?php } ?>
 
 <?= $this->data->trlKwf('To change you data or settings, click this link:'); ?><br />
-<a href="*showcomponent*<?= $this->editComponentId; ?>*"><?= $this->data->trlKwf('Settings'); ?></a><br /><br />
+<?=$this->componentLink($this->editComponent, $this->data->trlKwf('Settings')); ?><br /><br />
 
 <?= $this->data->trlKwf('Thanks for your subscription!'); ?><br />

--- a/Kwc/Newsletter/Subscribe/Mail/Mail.txt.tpl
+++ b/Kwc/Newsletter/Subscribe/Mail/Mail.txt.tpl
@@ -8,17 +8,17 @@
 
 <?= '-- '.$this->data->trlKwf('ACTIVATION LINK').' --'; ?>
 
-*showcomponent*<?= $this->doubleOptInComponentId; ?>*
+<?= $this->doubleOptInComponent->getAbsoluteUrl(); ?>
 
 <?php } else if ($this->unsubscribeComponentId) { ?>
 <?= $this->data->trlKwf('To unsubscribe anytime from our newsletter, click this link:'); ?>
 
-*showcomponent*<?= $this->unsubscribeComponentId; ?>*
+<?= $this->unsubscribeComponent->getAbsoluteUrl(); ?>
 
 <?php } ?>
 <?= $this->data->trlKwf('To change you data or settings, click this link:'); ?>
 
-*showcomponent*<?= $this->editComponentId; ?>*
+<?= $this->editComponent->getAbsoluteUrl(); ?>
 
 
 <?= $this->data->trlKwf('Thanks for your subscription!'); ?>

--- a/Kwc/Newsletter/Unsubscribe/Component.php
+++ b/Kwc/Newsletter/Unsubscribe/Component.php
@@ -10,17 +10,24 @@ class Kwc_Newsletter_Unsubscribe_Component extends Kwc_Abstract_Composite_Compon
         $ret['placeholder']['headline'] = trlKwfStatic('Unsubscribe newsletter');
         $ret['flags']['skipFulltext'] = true;
         $ret['flags']['noIndex'] = true;
+        $ret['flags']['processInput'] = true;
+        $ret['flags']['passMailRecipient'] = true;
         return $ret;
     }
 
-    public function processMailRedirectInput($recipient, $params)
+    public function processInput(array $postData)
     {
+        if (!isset($postData['recipient'])) {
+            throw new Kwf_Exception_NotFound();
+        }
+        $recipient = Kwc_Mail_Redirect_Component::parseRecipientParam($postData['recipient']);
+
         if (!($recipient instanceof Kwc_Mail_Recipient_UnsubscribableInterface)) {
             throw new Kwf_Exception("To unsubscribe from a newsletter, the recipient row must implement 'Kwc_Mail_Recipient_UnsubscribableInterface'");
         }
         $comp = $this->getData()->getChildComponent('-form')->getComponent();
         $comp->_recipient = $recipient;
-        $comp->processInput($params);
+        $comp->processInput($postData);
     }
 
 }

--- a/Kwc/Newsletter/Update/20150309Legacy34703.sql
+++ b/Kwc/Newsletter/Update/20150309Legacy34703.sql
@@ -1,2 +1,0 @@
-UPDATE kwc_mail_redirect SET value=CONCAT(SUBSTRING(value, 1, LENGTH(value)-12), '_unsubscribe') WHERE type='showcomponent' AND value LIKE '%-unsubscribe';
-UPDATE kwc_mail_redirect SET value=CONCAT(SUBSTRING(value, 1, LENGTH(value)-15), '_editSubscriber') WHERE type='showcomponent' AND value LIKE '%-editSubscriber';

--- a/Kwf/Component/View/Helper/ComponentLink.php
+++ b/Kwf/Component/View/Helper/ComponentLink.php
@@ -77,9 +77,6 @@ class Kwf_Component_View_Helper_ComponentLink extends Kwf_Component_View_Rendere
         }
 
         $url = $targetPage[0];
-        if ($this->_getRenderer() instanceof Kwf_Component_Renderer_Mail) {
-            $url = '*redirect*' . $url . '*';
-        }
 
         $helper = new Kwf_View_Helper_Link();
         $ret = $helper->getLink(

--- a/tests/Kwc/Mail/Redirect/Content/Mail.html.tpl
+++ b/tests/Kwc/Mail/Redirect/Content/Mail.html.tpl
@@ -1,2 +1,2 @@
-<a href="*redirect*http://www.vivid-planet.com**www.vivid-planet.com*">www.vivid-planet.com</a>
-<a href="*redirect*http://www.vivid-planet.at*">www.vivid-planet.at</a>
+<a href="http://www.vivid-planet.com">www.vivid-planet.com</a>
+<a href="http://www.vivid-planet.at">www.vivid-planet.at</a>

--- a/tests/Kwc/Mail/Redirect/Content/Mail.txt.tpl
+++ b/tests/Kwc/Mail/Redirect/Content/Mail.txt.tpl
@@ -1,2 +1,2 @@
-*redirect*http://www.vivid-planet.com**www.vivid-planet.com*
-*redirect*http://www.vivid-planet.at*
+http://www.vivid-planet.com
+http://www.vivid-planet.at


### PR DESCRIPTION
- drop showcomponent type in redirects, replaced by passMailRecipient flag

  processMailRedirectInput replaced by processInput plus call to Kwc_Mail_Redirect_Component::parseRecipientParam

- don't add `*redirect*` to urls in mail, now all urls will get redirect

  - html will be searched for <a href=""
  - text will be search for http://... (absolute urls for internal links are required)

- drop title for redirects
  was never really used and is not possible anymore without `*redirect*`

- The mail now can link to it's own page providing a *personalized* version of the mail
  whith all placeholders and redirect links working correctly