### PR TITLE
Add possibility to restrict uploads to mime type, filename and maximum size

### DIFF
--- a/Kwf/Acl/Resource/MediaUpload.php
+++ b/Kwf/Acl/Resource/MediaUpload.php
@@ -1,0 +1,28 @@
+<?php
+class Kwf_Acl_Resource_MediaUpload extends Zend_Acl_Resource
+{
+    private $_mimeTypePattern;
+    private $_filenamePattern;
+    private $_maxFilesize;
+
+    public function __construct($resourceId, $mimeTypePattern, $filenamePattern, $maxFilesize = null)
+    {
+        $this->_mimeTypePattern = $mimeTypePattern;
+        $this->_filenamePattern = $filenamePattern;
+        $this->_maxFilesize = $maxFilesize;
+        parent::__construct($resourceId);
+    }
+
+    public function getMimeTypePattern()
+    {
+        return $this->_mimeTypePattern;
+    }
+    public function getFilenamePattern()
+    {
+        return $this->_filenamePattern;
+    }
+    public function getMaxFilesize()
+    {
+        return $this->_maxFilesize;
+    }
+}

--- a/Kwf/Acl/Resource/MediaUpload/Image.php
+++ b/Kwf/Acl/Resource/MediaUpload/Image.php
@@ -1,0 +1,9 @@
+<?php
+class Kwf_Acl_Resource_MediaUpload_Image extends Kwf_Acl_Resource_MediaUpload
+{
+    public function __construct($resourceId, $maxFilesize = null)
+    {
+        parent::__construct($resourceId, 'image/.*', '(jpe?g|png|gif)$', $maxFilesize);
+    }
+}
+


### PR DESCRIPTION
usage exampe:
$this->addResource(new Kwf_Acl_Resource_MediaUpload('upload_image', 'image/.*', '(jpe?g|png|gif)$', 1024*1024*10));

or (the same):
$this->addResource(new Kwf_Acl_Resource_MediaUpload_Image('upload_image', 1024*1024*10));

(10MB is the maximum file size (optional))