### PR TITLE
Add default but optional noTags-validation to model

### DIFF
--- a/Kwf/Model/Abstract.php
+++ b/Kwf/Model/Abstract.php
@@ -1297,6 +1297,12 @@ abstract class Kwf_Model_Abstract implements Kwf_Model_Interface
                     $constraint = new $type($options);
                     $s['constraints'][] = $constraint;
                 }
+            } else {
+                $s['constraints'] = array();
+            }
+
+            if (!isset($s['allowTags']) || !$s['allowTags']) {
+                $s['constraints'][] = new KwfBundle\Validator\Constraints\NoTags();
             }
 
             if (array_intersect($groups, $s['groups'])) {

--- a/KwfBundle/Validator/Constraints/NoTags.php
+++ b/KwfBundle/Validator/Constraints/NoTags.php
@@ -1,0 +1,15 @@
+<?php
+namespace KwfBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class NoTags extends Constraint
+{
+    public $message = '';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+        $this->message = trlKwf("Must not include tags");
+    }
+}

--- a/KwfBundle/Validator/Constraints/NoTagsValidator.php
+++ b/KwfBundle/Validator/Constraints/NoTagsValidator.php
@@ -1,0 +1,26 @@
+<?php
+namespace KwfBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ExecutionContextInterface;
+
+class NoTagsValidator extends ConstraintValidator
+{
+    protected $kwfNoTagsValidator = false;
+
+    public function initialize(ExecutionContextInterface $context)
+    {
+        parent::initialize($context);
+        $this->kwfNoTagsValidator = new \Kwf_Validate_NoTags();
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$this->kwfNoTagsValidator->isValid($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $value)
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
This is a central solution to validate tags for all symfony-rest
controllers. The same validation is already in use for kwf-form-fields.
It's possible to allow tags by adding "allowTags" = true to column
in serialization definitions.