### PR TITLE
MediaCache: Implement collectGarbage maintenanceJob

### DIFF
--- a/Kwc/Abstract/Image/Component.php
+++ b/Kwc/Abstract/Image/Component.php
@@ -461,7 +461,6 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
 
     public static function canCacheBeDeleted($id)
     {
-        $cmp = Kwf_Component_Data_Root::getInstance()->getComponentById($id, array('ignoreVisible' => true));
-        return !$cmp;
+        return !Kwf_Component_Data_Root::getInstance()->getComponentById($id, array('ignoreVisible' => true));
     }
 }

--- a/Kwc/Abstract/Image/Component.php
+++ b/Kwc/Abstract/Image/Component.php
@@ -1,6 +1,6 @@
 <?php
 class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
-    implements Kwf_Media_Output_IsValidInterface
+    implements Kwf_Media_Output_IsValidInterface, Kwf_Media_Output_ClearCacheInterface
 {
     const USER_SELECT = Kwf_Form_Field_Image_UploadField::USER_SELECT;
     const CONTENT_WIDTH = Kwf_Form_Field_Image_UploadField::CONTENT_WIDTH;
@@ -457,5 +457,11 @@ class Kwc_Abstract_Image_Component extends Kwc_Abstract_Composite_Component
             $ret['normalContent'] = $text;
         }
         return $ret;
+    }
+
+    public static function canCacheBeDeleted($id)
+    {
+        $cmp = Kwf_Component_Data_Root::getInstance()->getComponentById($id, array('ignoreVisible' => true));
+        return !$cmp;
     }
 }

--- a/Kwc/Basic/DownloadTag/Component.php
+++ b/Kwc/Basic/DownloadTag/Component.php
@@ -1,6 +1,6 @@
 <?php
 class Kwc_Basic_DownloadTag_Component extends Kwc_Basic_LinkTag_Abstract_Component
-    implements Kwf_Media_Output_IsValidInterface
+    implements Kwf_Media_Output_IsValidInterface, Kwf_Media_Output_ClearCacheInterface
 {
     public static function getSettings($param = null)
     {
@@ -84,5 +84,10 @@ class Kwc_Basic_DownloadTag_Component extends Kwc_Basic_LinkTag_Abstract_Compone
             'mimeType' => $mimeType,
             'downloadFilename' => $filename
         );
+    }
+
+    public static function canCacheBeDeleted($id)
+    {
+        return !Kwf_Component_Data_Root::getInstance()->getComponentById($id, array('ignoreVisible' => true));
     }
 }

--- a/Kwf/Media.php
+++ b/Kwf/Media.php
@@ -238,7 +238,10 @@ class Kwf_Media
             $classFolder = $cacheFolder.'/'.$mediaClass;
             $groups = array_slice(scandir($classFolder), 2);
             foreach ($groups as $group) {
-                $groupFolder = $classFolder.'/'.$group;
+                // only check randomly one out of ten to improve performance
+                if (rand(0, 9) !== 0) continue;
+
+                $groupFolder = $classFolder . '/' . $group;
                 $ids = array_slice(scandir($groupFolder), 2);
                 foreach ($ids as $id) {
                     $idFolder = $groupFolder . '/' . $id;

--- a/Kwf/Media.php
+++ b/Kwf/Media.php
@@ -199,8 +199,7 @@ class Kwf_Media
             if ($useCache) {
                 if (isset($output['contents']) && strlen($output['contents']) > 20*1024) {
                     //don't cache contents larger than 20k in apc, use separate file cache
-                    $groupingFolder = substr(md5($id), 0, 2);
-                    $cacheFileName = Kwf_Config::getValue('mediaCacheDir').'/'.$class.'/'.$groupingFolder.'/'.$id.'/'.$type;
+                    $cacheFileName = self::_generateCacheFilePath($class, $id, $type);
                     if (!is_dir(dirname($cacheFileName))) @mkdir(dirname($cacheFileName), 0777, true);
                     file_put_contents($cacheFileName, $output['contents']);
                     $output['file'] = $cacheFileName;
@@ -218,5 +217,45 @@ class Kwf_Media
     public static function createCacheId($class, $id, $type)
     {
         return str_replace(array('.', '>'), array('___', '____'), $class) . '_' . str_replace('-', '__', $id) . '_' . $type;
+    }
+
+    private static function _generateCacheFilePath($class, $id, $type)
+    {
+        $groupingFolder = substr(md5($id), 0, 3);
+        return Kwf_Config::getValue('mediaCacheDir').'/'.$class.'/'.$groupingFolder.'/'.$id.'/'.$type;
+    }
+
+    public static function collectGarbage($debug)
+    {
+        $cacheFolder = Kwf_Config::getValue('mediaCacheDir');
+        // get all folders, except . and .. (array_slice)
+        $mediaClasses = array_slice(scandir($cacheFolder), 2);
+        foreach ($mediaClasses as $mediaClass) {
+            if (is_file($cacheFolder.'/'.$mediaClass)) continue;
+
+            if (!is_instance_of($mediaClass, 'Kwf_Media_Output_ClearCacheInterface')) continue;
+
+            $classFolder = $cacheFolder.'/'.$mediaClass;
+            $groups = array_slice(scandir($classFolder), 2);
+            foreach ($groups as $group) {
+                $groupFolder = $classFolder.'/'.$group;
+                $ids = array_slice(scandir($groupFolder), 2);
+                foreach ($ids as $id) {
+                    $idFolder = $groupFolder . '/' . $id;
+                    if (is_file($idFolder)) continue; // something old...
+
+                    $canCacheBeDeleted = call_user_func(array($mediaClass, 'canCacheBeDeleted'), $id);
+                    if (!$canCacheBeDeleted) continue;
+
+                    $types = array_slice(scandir($idFolder), 2);
+                    foreach ($types as $type) {
+                        unlink(realpath($idFolder . '/' . $type));
+                        $cacheId = self::createCacheId($mediaClass, $id, $type);
+                        Kwf_Media_OutputCache::getInstance()->remove($cacheId);
+                    }
+                    rmdir(realpath($idFolder));
+                }
+            }
+        }
     }
 }

--- a/Kwf/Media/CollectGarbageMaintenanceJob.php
+++ b/Kwf/Media/CollectGarbageMaintenanceJob.php
@@ -1,0 +1,13 @@
+<?php
+class Kwf_Media_CollectGarbageMaintenanceJob extends Kwf_Util_Maintenance_Job_Abstract
+{
+    public function getFrequency()
+    {
+        return self::FREQUENCY_DAILY;
+    }
+
+    public function execute($debug)
+    {
+        Kwf_Media::collectGarbage($debug);
+    }
+}

--- a/Kwf/Media/Output/ClearCacheInterface.php
+++ b/Kwf/Media/Output/ClearCacheInterface.php
@@ -1,0 +1,5 @@
+<?php
+interface Kwf_Media_Output_ClearCacheInterface
+{
+    public static function canCacheBeDeleted($id);
+}


### PR DESCRIPTION
Iterates over directories and files and check if MediaOutput implements
ClearCacheInterface. It's not called for every type because in most
cases it's all or nothing and it doesn't hurt if there are a few more
entries.