### PR TITLE
Fix show and hide options for menuentries on mobile to work again.

### DIFF
--- a/Kwc/Menu/Abstract/Component.scss
+++ b/Kwc/Menu/Abstract/Component.scss
@@ -1,16 +1,16 @@
 @import "kwf/mobile-breakpoint";
 
 .kwfUp-webStandard.kwcClass {
-    > .kwcbem__item--onlyShowOnMobile {
+    .kwcBem__item--onlyShowOnMobile {
         display: none;
     }
 
     @include mobile-breakpoint {
-        > .kwcbem__item--onlyShowOnMobile {
+        .kwcBem__item--onlyShowOnMobile {
             display: block;
         }
 
-        > .kwcbem__item--hideOnMobile {
+        .kwcBem__item--hideOnMobile {
             display: none;
         }
     }


### PR DESCRIPTION
The structur in our mainmenu is like nav.kwcClass->ul.menu->li.item. For this constellation the css, wish shows or hides the menuitems according to the pagesettings from the backend, had no effect.
Now the css should be applied on all items in all levels.