### PR TITLE
Add config setting to disable fail notifications of maintenance jobs

### DIFF
--- a/Kwf/Util/Maintenance/Dispatcher.php
+++ b/Kwf/Util/Maintenance/Dispatcher.php
@@ -126,7 +126,7 @@ class Kwf_Util_Maintenance_Dispatcher
         if ($debug) echo "\n";
 
         $runRow->save();
-        if ($runRow->status != 'success') {
+        if ($runRow->status != 'success' && Kwf_Config::getValue('maintenanceJobs.sendFailNotification')) {
             $recipients = $job->getRecipientsForFailNotification();
             if (is_null($recipients)) {
                 $recipients = Kwf_Config::getValue('maintenanceJobs.failNotificationRecipient');

--- a/config.ini
+++ b/config.ini
@@ -75,6 +75,7 @@ debug.queryTimeout = false
 ; debug.dbBuffer = false
 ; debug.twig = false
 maintenanceJobs.failNotificationRecipient = false
+maintenanceJobs.sendFailNotification = true
 
 debug.duckcast.host = false
 debug.duckcast.port = 3800
@@ -228,3 +229,4 @@ fulltext.solr.basePath = /test.%appid%
 clearCacheSkipProcessControl = true
 symfony.environment = test
 node_env = test
+maintenanceJobs.sendFailNotification = false


### PR DESCRIPTION
Fail notifications are enabled on production and disabled on test by default.