### PR TITLE
Add CSRF Protection Event Listener to KwfBundle

### DIFF
--- a/KwfBundle/EventListener/CsrfProtection.php
+++ b/KwfBundle/EventListener/CsrfProtection.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace KwfBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+class CsrfProtection
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+        if ($request->headers->get('X-Requested-With') !== 'XMLHttpRequest') {
+            throw new AccessDeniedHttpException('Missing X-Requested-With header');
+        }
+    }
+}

--- a/KwfBundle/Resources/config/services.yml
+++ b/KwfBundle/Resources/config/services.yml
@@ -55,3 +55,8 @@ services:
         class: KwfBundle\EventListener\ModelObserverProcess
         tags:
             - { name: kernel.event_listener, event: kernel.terminate }
+
+    kwf.crsfprotection_listener:
+        class: KwfBundle\EventListener\CsrfProtection
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, priority: 12 }


### PR DESCRIPTION
This event listener throws and access denied error if the request does not have the X-Requested-With:XMLHttpRequest header.
If the API is used by any external service lika a native app, you have to override the service and implement your own whitelist.