### PR TITLE
Fix wrong top offset on success

### DIFF
--- a/Kwc/Mail/Redirect/Component.php
+++ b/Kwc/Mail/Redirect/Component.php
@@ -168,7 +168,7 @@ class Kwc_Mail_Redirect_Component extends Kwc_Abstract
         if ($mode == 'mailhtml' || $mode == 'html') {
             $that = $this;
             $mailText = preg_replace_callback('#(<a [^>]*href=")([^>"]+)()#', function($m) use ($that, $recipient) {
-                $link = Kwf_Util_HtmlSpecialChars::filter_decode($m[2]);
+                $link = Kwf_Util_HtmlSpecialChars::decode($m[2]);
                 $link = $that->_createRedirectUrl($link, $recipient);
                 return $m[1].Kwf_Util_HtmlSpecialChars::filter($link).$m[3];
             }, $mailText);

--- a/Kwc/Shop/AddToCartAbstract/FrontendForm.php
+++ b/Kwc/Shop/AddToCartAbstract/FrontendForm.php
@@ -1,7 +1,7 @@
 <?php
 class Kwc_Shop_AddToCartAbstract_FrontendForm extends Kwf_Form
 {
-    protected function _beforeInsert($row)
+    protected function _beforeInsert(Kwf_Model_Row_Interface $row)
     {
         if (!$row->amount) {
             $row->amount = 1;

--- a/Kwc/Shop/Box/CartLink/Component.defer.js
+++ b/Kwc/Shop/Box/CartLink/Component.defer.js
@@ -1,25 +1,29 @@
+var $ = require('jQuery');
 var onReady = require('kwf/on-ready');
 var getKwcRenderUrl = require('kwf/get-kwc-render-url');
 
 onReady.onContentReady(function(readyEl, param) {
     if (!param.newRender) return false;
-    Ext2.select('.kwfUp-kwcForm > form', true, readyEl).each(function(form) {
-        form = form.parent('.kwfUp-kwcForm', false);
-        if (form.dom.shopBoxCartInitDone) return;
-        form.dom.shopBoxCartInitDone = true;
-        form.kwcForm.on('submitSuccess', function(r) {
-            Ext2.select('.kwcShopBoxCartLink').each(function(el) {
-                Ext2.Ajax.request({
-                    params: { componentId: el.dom.id },
-                    url: getKwcRenderUrl(),
-                    success: function(response, options) {
-                        $(this.dom).html($(response.responseText).html());
-                        onReady.callOnContentReady(this.dom, {newRender: true});
-                    },
-                    scope: el
-                });
 
-            }, this);
-        }, this);
+    $('.kwfUp-kwcForm > .kwfUp-formContainer > form').each(function(index, form) {
+        form = $(form).parents('.kwfUp-kwcForm');
+        if (form.get(0).shopBoxCartInitDone) return;
+        form.get(0).shopBoxCartInitDone = true;
+
+        form.get(0).kwcForm.on('submitSuccess', function(r) {
+            $('.kwcShopBoxCartLink').each(function(i, el) {
+                $.ajax({
+                    url: getKwcRenderUrl(),
+                    data: {
+                        componentId: el.id
+                    },
+                    success: function (responseText) {
+                        $(el).html($(responseText).html());
+                        onReady.callOnContentReady(el, {newRender: true});
+                    }
+                })
+            });
+        });
+
     });
 }, { priority: 0 }); //call after Kwc.Form.Component

--- a/Kwc/Shop/Cart/Checkout/Form/FrontendForm.php
+++ b/Kwc/Shop/Cart/Checkout/Form/FrontendForm.php
@@ -81,7 +81,7 @@ class Kwc_Shop_Cart_Checkout_Form_FrontendForm extends Kwf_Form
     }
 
 
-    public function validate($parentRow, array $postData = array())
+    public function validate($parentRow, $postData = array())
     {
         $ret = parent::validate($parentRow, $postData);
         if ($this->getAllowEmptyCart() !== true) {

--- a/Kwc/Shop/Cart/Checkout/OrdersController.php
+++ b/Kwc/Shop/Cart/Checkout/OrdersController.php
@@ -6,7 +6,7 @@ class Kwc_Shop_Cart_Checkout_OrdersController_Payment extends Kwf_Data_Abstract
     {
         $this->_payments = $payments;
     }
-    public function load($row)
+    public function load($row, array $info = array())
     {
         if (!isset($this->_payments[$row->payment])) return $row->payment;
         return $this->_payments[$row->payment];
@@ -14,7 +14,7 @@ class Kwc_Shop_Cart_Checkout_OrdersController_Payment extends Kwf_Data_Abstract
 }
 class Kwc_Shop_Cart_Checkout_OrdersController_SumAmount extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $ret = 0;
         foreach ($row->getChildRows('Products') as $p) {
@@ -26,7 +26,7 @@ class Kwc_Shop_Cart_Checkout_OrdersController_SumAmount extends Kwf_Data_Abstrac
 }
 class Kwc_Shop_Cart_Checkout_OrdersController_SumPrice extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         return $row->getTotal();
     }

--- a/Kwc/Shop/Cart/Checkout/Payment/Abstract/Mail/Component.php
+++ b/Kwc/Shop/Cart/Checkout/Payment/Abstract/Mail/Component.php
@@ -22,11 +22,11 @@ class Kwc_Shop_Cart_Checkout_Payment_Abstract_Mail_Component extends Kwc_Mail_Ed
             . Kwf_Trl::getInstance()->trlStaticExecute(Kwc_Abstract::getSetting($this->getData()->parent->componentClass, 'componentName'));
     }
 
-    public function getPlaceholders(Kwc_Shop_Cart_Order $o = null)
+    public function getPlaceholders(Kwc_Mail_Recipient_Interface $recipient = null)
     {
-        $ret = parent::getPlaceholders($o);
-        if ($o) {
-            $ret = array_merge($ret, $o->getPlaceholders());
+        $ret = parent::getPlaceholders($recipient);
+        if ($recipient) {
+            $ret = array_merge($ret, $recipient->getPlaceholders());
         }
         return $ret;
     }

--- a/Kwc/Shop/Cart/Checkout/Payment/Abstract/OrderTable/Component.twig
+++ b/Kwc/Shop/Cart/Checkout/Payment/Abstract/OrderTable/Component.twig
@@ -28,7 +28,7 @@
                 <table class="tblCheckoutPrice" cellspacing="0" cellpadding="0">
                     {% for row in sumRows %}
                     <tr{% if (row.class is defined) %} class="{{ row.class }}"{% endif %}>
-                        <td>{{ data.trlStaticExecute(row.text) }}</td>
+                        <td>{{ data.trlStaticExecute(row.text)|raw }}</td>
                         <td class="price">{{ row.amount|money }}</td>
                     </tr>
                     {% endfor %}

--- a/Kwc/Shop/Cart/Checkout/Payment/Abstract/ShippedMail/Component.php
+++ b/Kwc/Shop/Cart/Checkout/Payment/Abstract/ShippedMail/Component.php
@@ -22,11 +22,11 @@ class Kwc_Shop_Cart_Checkout_Payment_Abstract_ShippedMail_Component extends Kwc_
             . Kwf_Trl::getInstance()->trlStaticExecute(Kwc_Abstract::getSetting($this->getData()->parent->componentClass, 'componentName'));
     }
 
-    public function getPlaceholders(Kwc_Shop_Cart_Order $o = null)
+    public function getPlaceholders(Kwc_Mail_Recipient_Interface $recipient = null)
     {
-        $ret = parent::getPlaceholders($o);
-        if ($o) {
-            $ret = array_merge($ret, $o->getPlaceholders());
+        $ret = parent::getPlaceholders($recipient);
+        if ($recipient) {
+            $ret = array_merge($ret, $recipient->getPlaceholders());
         }
         return $ret;
     }

--- a/Kwc/Shop/Cart/Checkout/ProductData/Amount.php
+++ b/Kwc/Shop/Cart/Checkout/ProductData/Amount.php
@@ -1,7 +1,7 @@
 <?php
 class Kwc_Shop_Cart_Checkout_ProductData_Amount extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $data = Kwc_Shop_AddToCartAbstract_OrderProductData::getInstance($row->add_component_class);
         return $data->getAmount($row);

--- a/Kwc/Shop/Cart/Checkout/ProductData/Info.php
+++ b/Kwc/Shop/Cart/Checkout/ProductData/Info.php
@@ -1,7 +1,7 @@
 <?php
 class Kwc_Shop_Cart_Checkout_ProductData_Info extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $data = Kwc_Shop_AddToCartAbstract_OrderProductData::getInstance($row->add_component_class);
         $parts = array();

--- a/Kwc/Shop/Cart/Checkout/ProductData/Price.php
+++ b/Kwc/Shop/Cart/Checkout/ProductData/Price.php
@@ -1,7 +1,7 @@
 <?php
 class Kwc_Shop_Cart_Checkout_ProductData_Price extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $data = Kwc_Shop_AddToCartAbstract_OrderProductData::getInstance($row->add_component_class);
         return $data->getPrice($row);

--- a/Kwc/Shop/Cart/Checkout/ProductData/ProductText.php
+++ b/Kwc/Shop/Cart/Checkout/ProductData/ProductText.php
@@ -1,7 +1,7 @@
 <?php
 class Kwc_Shop_Cart_Checkout_ProductData_ProductText extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $data = Kwc_Shop_AddToCartAbstract_OrderProductData::getInstance($row->add_component_class);
         return $data->getProductText($row);

--- a/Kwc/Shop/Cart/Plugins/Voucher/Component.php
+++ b/Kwc/Shop/Cart/Plugins/Voucher/Component.php
@@ -31,7 +31,8 @@ class Kwc_Shop_Cart_Plugins_Voucher_Component extends Kwf_Component_Plugin_Abstr
             $amount = -min($total, $row->amount - $row->used_amount);
             $remainingAmount = $row->amount - $row->used_amount + $amount;
             if ($remainingAmount > 0) {
-                $text .= ' ('.trlKwfStatic('Remaining Amount {0}', Kwf_View_Helper_Money::money($remainingAmount)).')';
+                $helper = new Kwf_View_Helper_Money();
+                $text .= ' ('.trlKwfStatic('Remaining Amount {0}', $helper->money($remainingAmount)).')';
             }
         }
 
@@ -81,9 +82,11 @@ class Kwc_Shop_Cart_Plugins_Voucher_Component extends Kwf_Component_Plugin_Abstr
 
     public function getPlaceholders(Kwc_Shop_Cart_Order $order)
     {
+        $helper = new Kwf_View_Helper_Money();
+
         $remainingAmount = (float)$order->voucher_remaining_amount;
         return array(
-            'voucherRemainingAmount' => Kwf_View_Helper_Money::money($remainingAmount)
+            'voucherRemainingAmount' => $helper->money($remainingAmount)
         );
     }
 }

--- a/Kwc/Shop/Cart/Trl/Component.php
+++ b/Kwc/Shop/Cart/Trl/Component.php
@@ -8,7 +8,7 @@ class Kwc_Shop_Cart_Trl_Component extends Kwc_Directories_Item_Directory_Trl_Com
         return $ret;
     }
 
-    public function preProcessInput()
+    public function preProcessInput($postData)
     {
         // to remove deleted products from the cart
         Kwf_Model_Abstract::getInstance(Kwc_Abstract::getSetting($this->getData()->chained->componentClass, 'childModel'))

--- a/Kwc/Shop/Products/Detail/RelatedProducts/Product/Admin.php
+++ b/Kwc/Shop/Products/Detail/RelatedProducts/Product/Admin.php
@@ -3,8 +3,11 @@ class Kwc_Shop_Products_Detail_RelatedProducts_Product_Admin extends Kwc_Abstrac
 {
     public function componentToString(Kwf_Component_Data $data)
     {
-        $model = Kwf_Model_Abstract::getInstance('Kwc_Shop_Products');
-        return $model->getRow($data->getComponent()->getRow()->product_id)->__toString();
+        $ret = '';
+        if ($productId = $data->getComponent()->getRow()->product_id) {
+            $ret = Kwf_Model_Abstract::getInstance('Kwc_Shop_Products')->getRow($productId)->__toString();
+        }
+        return $ret;
     }
 
     public function gridColumns()

--- a/Kwc/Shop/VoucherProduct/AddToCart/OrderProductData.php
+++ b/Kwc/Shop/VoucherProduct/AddToCart/OrderProductData.php
@@ -15,10 +15,11 @@ class Kwc_Shop_VoucherProduct_AddToCart_OrderProductData extends Kwc_Shop_AddToC
     {
         $ret = parent::getAdditionalOrderData($orderProduct);
         /*
+        $helper = new Kwf_View_Helper_Money();
         $ret[] = array(
             'class' => 'amount',
             'name' => trlcKwf('Amount of Money', 'Amount'),
-            'value' => Kwf_View_Helper_Money::money($orderProduct->amount)
+            'value' => $helper->money($orderProduct->amount)
         );
         */
         return $ret;

--- a/Kwc/Statistics/Opt/Trl/Component.php
+++ b/Kwc/Statistics/Opt/Trl/Component.php
@@ -1,0 +1,28 @@
+<?php
+class Kwc_Statistics_Opt_Trl_Component extends Kwc_Abstract_Composite_Trl_Component
+{
+    public static function getSettings($masterComponentClass = null)
+    {
+        $ret = parent::getSettings($masterComponentClass);
+        $ret['ownModel'] = 'Kwf_Component_FieldModel';
+        return $ret;
+    }
+
+    public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer)
+    {
+        $ret = parent::getTemplateVars($renderer);
+        $config = array();
+        $config['textOptIn'] = $this->getRow()->text_opt_in;
+        if (!$config['textOptIn']) {
+            $config['textOptIn'] = $this->getData()->trlKwf('Cookies are set when visiting this webpage. Click to deactivate cookies.');
+        }
+        $config['textOptOut'] = $this->getRow()->text_opt_out;
+        if (!$config['textOptOut']) {
+            $config['textOptOut'] = $this->getData()->trlKwf('No cookies are set when visiting this webpage. Click to activate cookies.');
+        }
+        $config['textOptIn'] = nl2br($config['textOptIn']);
+        $config['textOptOut'] = nl2br($config['textOptOut']);
+        $ret['config'] = $config;
+        return $ret;
+    }
+}

--- a/Kwc/Statistics/Opt/Trl/Form.php
+++ b/Kwc/Statistics/Opt/Trl/Form.php
@@ -1,0 +1,19 @@
+<?php
+class Kwc_Statistics_Opt_Trl_Form extends Kwc_Abstract_Composite_Trl_Form
+{
+    protected function _initFields()
+    {
+        $this->add(new Kwf_Form_Field_TextArea('text_opt_in', trlKwf('Text for opt-in')))
+            ->setDefaultValue(trlKwf('Cookies are set when visiting this webpage. Click to deactivate cookies.'))
+            ->setWidth(500)
+            ->setHeight(100);
+        $this->add(new Kwf_Form_Field_ShowField('original_text_opt_in', trlKwf('Original Text for opt-in')))
+            ->setData(new Kwf_Data_Trl_OriginalComponent('text_opt_in'));
+        $this->add(new Kwf_Form_Field_TextArea('text_opt_out', trlKwf('Text for opt-out')))
+            ->setDefaultValue(trlKwf('No cookies are set when visiting this webpage. Click to activate cookies.'))
+            ->setWidth(500)
+            ->setHeight(100);
+        $this->add(new Kwf_Form_Field_ShowField('original_text_opt_out', trlKwf('Original Text for opt-out')))
+            ->setData(new Kwf_Data_Trl_OriginalComponent('text_opt_out'));
+    }
+}

--- a/Kwc/User/Login/Form/Component.php
+++ b/Kwc/User/Login/Form/Component.php
@@ -6,7 +6,6 @@ class Kwc_User_Login_Form_Component extends Kwc_Form_Component
         $ret = parent::getSettings($param);
         $ret['placeholder']['submitButton'] = trlKwfStatic('Login');
         $ret['generators']['child']['component']['success'] = 'Kwc_User_Login_Form_Success_Component';
-        $ret['plugins'][] = 'Kwc_User_Login_Form_UseViewCachePlugin';
         return $ret;
     }
 

--- a/Kwc/User/Login/Form/UseViewCachePlugin.php
+++ b/Kwc/User/Login/Form/UseViewCachePlugin.php
@@ -1,9 +1,0 @@
-<?php
-class Kwc_User_Login_Form_UseViewCachePlugin extends Kwf_Component_Plugin_Abstract
-    implements Kwf_Component_Plugin_Interface_UseViewCache
-{
-    public function useViewCache($renderer)
-    {
-        return !isset($_REQUEST['redirect']);
-    }
-}

--- a/Kwf/Component/Abstract/ContentSender/Default.php
+++ b/Kwf/Component/Abstract/ContentSender/Default.php
@@ -63,6 +63,9 @@ class Kwf_Component_Abstract_ContentSender_Default extends Kwf_Component_Abstrac
     {
         if ($this->_data->getBaseProperty('preLogin')) {
             $ignore = false;
+            foreach (Kwf_Config::getValueArray('preLoginIgnore') as $i) {
+                if (substr($_SERVER['REDIRECT_URL'], 0, strlen($i)) == $i) $ignore  = true;
+            }
             foreach (Kwf_Config::getValueArray('preLoginIgnoreIp') as $i) {
                 $ip = $_SERVER['REMOTE_ADDR'];
                 if ($ip == $i) $ignore = true;
@@ -75,7 +78,7 @@ class Kwf_Component_Abstract_ContentSender_Default extends Kwf_Component_Abstrac
                     if (substr($ip, -strlen($i)) == $i) $ignore = true;
                 }
             }
-            Kwf_Setup::checkPreLogin($this->_data->getBaseProperty('preLoginUser'), $this->_data->getBaseProperty('preLoginPassword'));
+            if (!$ignore) Kwf_Setup::checkPreLogin($this->_data->getBaseProperty('preLoginUser'), $this->_data->getBaseProperty('preLoginPassword'));
         }
 
         $benchmarkEnabled = Kwf_Benchmark::isEnabled();

--- a/Kwf/Component/Partial/Random.php
+++ b/Kwf/Component/Partial/Random.php
@@ -14,7 +14,7 @@ class Kwf_Component_Partial_Random extends Kwf_Component_Partial_Abstract
         return array_keys($random);
     }
 
-    public static function useViewCache()
+    public static function useViewCache($componentId, $params)
     {
         return false;
     }

--- a/Kwf/Controller/Action/Cli/Web/ComponentPagesMetaController.php
+++ b/Kwf/Controller/Action/Cli/Web/ComponentPagesMetaController.php
@@ -136,9 +136,10 @@ class Kwf_Controller_Action_Cli_Web_ComponentPagesMetaController extends Kwf_Con
         }
 
         if ($this->_getParam('debug')) {
+            $secondsAsDurationHelper = new Kwf_View_Helper_SecondsAsDuration();
             $stats = unserialize(file_get_contents($statsFile));
             echo "fulltext reindex finished.\n";
-            echo "duration: ".Kwf_View_Helper_SecondsAsDuration::secondsAsDuration(microtime(true)-$startTime)."s\n";
+            echo "duration: ".$secondsAsDurationHelper->secondsAsDuration(microtime(true)-$startTime)."s\n";
             echo "used child processes: $numProcesses\n";
             echo "processed pages: $stats[pages]\n";
             echo "indexed pages: $stats[addedPages]\n";

--- a/Kwf/Controller/Action/Cli/Web/FulltextController.php
+++ b/Kwf/Controller/Action/Cli/Web/FulltextController.php
@@ -137,7 +137,11 @@ class Kwf_Controller_Action_Cli_Web_FulltextController extends Kwf_Controller_Ac
             $countIndexed++;
             if ($this->_getParam('debug')) echo "changed: $row->page_id\n";
             $page = Kwf_Component_Data_Root::getInstance()->getComponentById($row->page_id);
-            if (!$page) {
+
+            $newDoc = false;
+            if ($page) $newDoc = Kwf_Util_Fulltext_Backend_Abstract::getInstance()->getFulltextContentForPage($page);
+
+            if (!$newDoc) {
                 if ($this->_getParam('debug')) echo "deleting $row->page_id\n";
                 $sr = Kwf_Component_Data_Root::getInstance()->getComponentById($row->subroot_component_id, array('ignoreVisible' => true));
                 if ($sr) {

--- a/Kwf/Controller/Action/Cli/Web/MaintenanceJobsController.php
+++ b/Kwf/Controller/Action/Cli/Web/MaintenanceJobsController.php
@@ -56,7 +56,7 @@ class Kwf_Controller_Action_Cli_Web_MaintenanceJobsController extends Kwf_Contro
 
                 //discard connection to database to reconnect on next job run
                 //avoids problems with auto closed connections due to inactivity
-                if (function_exists('gc_collect_cycles()')) {
+                if (function_exists('gc_collect_cycles')) {
                     Kwf_Model_Abstract::clearAllRows();
                     Kwf_Model_Abstract::clearInstances();
                     gc_collect_cycles();

--- a/Kwf/Controller/Action/User/ChangeuserController.php
+++ b/Kwf/Controller/Action/User/ChangeuserController.php
@@ -22,10 +22,11 @@ class Kwf_Controller_Action_User_ChangeuserController extends Kwf_Controller_Act
         $authedChangedRole = Zend_Registry::get('userModel')->getAuthedChangedUserRole();
         $acl = Zend_Registry::get('acl');
         if (!($acl->getRole($authedChangedRole) instanceof Kwf_Acl_Role_Admin)) {
-            //wenn nicht superuser
-            foreach ($acl->getRoles() as $role) {
+            $roles = array();
+            foreach ($acl->getAllowedEditResourceRoleIdsByRole($authedChangedRole) as $roleId) {
+                $role = $acl->getRole($roleId);
                 if ($role instanceof Kwf_Acl_Role && !($role instanceof Kwf_Acl_Role_Admin)) {
-                    $roles[] = $role->getRoleId();
+                    $roles[] = $roleId;
                 }
             }
             $roles = array_values(array_unique($roles));

--- a/Kwf/Exception/Abstract.php
+++ b/Kwf/Exception/Abstract.php
@@ -8,6 +8,14 @@ abstract class Kwf_Exception_Abstract extends Exception
 
     public abstract function log();
 
+    public function __construct($message = '', $code = 0, Exception $previous = null)
+    {
+        parent::__construct(
+            Kwf_Util_HtmlSpecialChars::filter($message),
+            $code,
+            $previous);
+    }
+
     public function setLogId($logId)
     {
         $this->_logId = $logId;

--- a/Kwf/Form/Field/PoolSelect.php
+++ b/Kwf/Form/Field/PoolSelect.php
@@ -6,7 +6,7 @@ class Kwf_Form_Field_PoolSelect extends Kwf_Form_Field_Select
 {
     public function setPool($pool)
     {
-        $table = new Kwf_Dao_Pool();
+        $table = new Kwf_Util_Model_Pool();
         $this->setValues($table->fetchAll(array('pool = ?' => $pool), 'pos'));
         return $this;
     }

--- a/Kwf/Media.php
+++ b/Kwf/Media.php
@@ -225,6 +225,19 @@ class Kwf_Media
         return Kwf_Config::getValue('mediaCacheDir').'/'.$class.'/'.$groupingFolder.'/'.$id.'/'.$type;
     }
 
+    private static function _deleteFolder($path)
+    {
+        foreach (array_slice(scandir($path), 2) as $fileOrFolder) {
+            $fileOrFolderPath = $path.'/'.$fileOrFolder;
+            if (is_file($fileOrFolderPath)) {
+                unlink($fileOrFolderPath);
+            } else {
+                self::_deleteFolder($fileOrFolderPath);
+            }
+        }
+        rmdir($path);
+    }
+
     public static function collectGarbage($debug)
     {
         $cacheFolder = Kwf_Config::getValue('mediaCacheDir');
@@ -232,6 +245,11 @@ class Kwf_Media
         $mediaClasses = array_slice(scandir($cacheFolder), 2);
         foreach ($mediaClasses as $mediaClass) {
             if (is_file($cacheFolder.'/'.$mediaClass)) continue;
+
+            if (!class_exists($mediaClass)) {
+                self::_deleteFolder($cacheFolder.'/'.$mediaClass);
+                continue;
+            }
 
             if (!is_instance_of($mediaClass, 'Kwf_Media_Output_ClearCacheInterface')) continue;
 

--- a/Kwf/User/Model.php
+++ b/Kwf/User/Model.php
@@ -267,6 +267,12 @@ class Kwf_User_Model extends Kwf_Model_RowCache
 
     public function getAuthedChangedUserRole()
     {
+        $user = $this->getAuthedChangedUser();
+        return $user ? $user->role : 'guest';
+    }
+
+    public function getAuthedChangedUser()
+    {
         $storage = Kwf_Auth::getInstance()->getStorage();
         $loginData = $storage->read();
         $userId = false;
@@ -276,11 +282,9 @@ class Kwf_User_Model extends Kwf_Model_RowCache
             $userId = $loginData['userId'];
         }
         if ($userId && ($user = $this->getRow($userId))) {
-            $role = $user->role;
-        } else {
-            $role = 'guest';
+            return $user;
         }
-        return $role;
+        return null;
     }
 
     public function changeUser($user)

--- a/Kwf/Util/Hash.php
+++ b/Kwf/Util/Hash.php
@@ -10,7 +10,10 @@ class Kwf_Util_Hash
             } else {
                 $hashFile = 'cache/hashprivatepart';
                 if (!file_exists($hashFile)) {
-                    file_put_contents($hashFile, time().rand(100000, 1000000));
+                    if (!function_exists('random_bytes')) {
+                        require 'vendor/paragonie/random_compat/lib/random.php';
+                    }
+                    file_put_contents($hashFile, bin2hex(random_bytes(32)));
                 }
                 $salt = file_get_contents($hashFile);
                 Kwf_Cache_SimpleStatic::add('hashpp-', $salt);

--- a/Kwf/Util/HtmlSpecialChars.php
+++ b/Kwf/Util/HtmlSpecialChars.php
@@ -5,4 +5,9 @@ class Kwf_Util_HtmlSpecialChars
     {
         return htmlspecialchars($value, ENT_QUOTES);
     }
+
+    public static function decode($value)
+    {
+        return htmlspecialchars_decode($value, ENT_QUOTES);
+    }
 }

--- a/Kwf_js/EyeCandy/Switch/Display.js
+++ b/Kwf_js/EyeCandy/Switch/Display.js
@@ -15,8 +15,8 @@ var $ = require('jQuery');
         $.extend(this.config, config);
 
         this.el = $(el);
-        this.switchLink = this.el.find(this.config.link || '.kwfUp-switchLink');
-        this.switchContainer = this.el.find(this.config.container || '.kwfUp-switchContent');
+        this.switchLink = this.el.find(this.config.link || '.kwfUp-switchLink:first');
+        this.switchContainer = this.el.find(this.config.container || '.kwfUp-switchContent:first');
         this.boundEvent = this.config.hover ? 'hover' : 'click';
         this.activeTimeout = null;
 
@@ -99,15 +99,15 @@ var $ = require('jQuery');
                 priority: -1 // initialize before tabs
             });
             onReady.onRender(elOrSelector, function(el, config) {
-                if (!el.find(config.container || 'div.kwfUp-switchContent').hasClass('kwfUp-active')) {
-                    el.find(config.container || 'div.kwfUp-switchContent').hide();
+                if (!el.find(config.container || 'div.kwfUp-switchContent:first').hasClass('kwfUp-active')) {
+                    el.find(config.container || 'div.kwfUp-switchContent:first').hide();
                 }
             });
         } else {
             config = config || {};
             el = elOrSelector;
-            if (!el.find(config.container || 'div.kwfUp-switchContent').hasClass('kwfUp-active')) {
-                el.find(config.container || 'div.kwfUp-switchContent').hide();
+            if (!el.find(config.container || 'div.kwfUp-switchContent:first').hasClass('kwfUp-active')) {
+                el.find(config.container || 'div.kwfUp-switchContent:first').hide();
             }
             el = elOrSelector.get(0);
 

--- a/Kwf_js/Menu/Index.js
+++ b/Kwf_js/Menu/Index.js
@@ -191,7 +191,7 @@ Kwf.Menu.Index = Ext2.extend(Ext2.Toolbar,
         if (result.fullname && result.userSelfControllerUrl) {
             this.userToolbar.add({
                 id: 'currentUser',
-                text: result.fullname,
+                text: Ext2.util.Format.htmlEncode(result.fullname),
                 cls: 'x2-btn-text-icon',
                 icon: '/assets/silkicons/user.png',
                 disabled: !result.userId,

--- a/commonjs/frontend-form/form.js
+++ b/commonjs/frontend-form/form.js
@@ -250,9 +250,10 @@ FormComponent.prototype = {
                 }
 
                 var scrollTo = null;
+
                 if (!hasErrors) {
                     // Scroll to top of form
-                    scrollTo = this.el.offset().top;
+                    scrollTo = this.el.parent().offset().top;
                 } else {
                     // Scroll to first error. If there are form-errors those are first
                     if (!r.errorMessages.length) { // there are no form-errors
@@ -269,7 +270,7 @@ FormComponent.prototype = {
                     }
                     if (scrollTo == null) { // no field errors found or only form errors
                         // form-errors are shown at the top of the form
-                        scrollTo = this.el.offset().top;
+                        scrollTo = this.el.parent().offset().top;
                     }
                 }
                 if (scrollTo != null) {

--- a/commonjs/on-ready.js
+++ b/commonjs/on-ready.js
@@ -146,7 +146,9 @@ var callOnContentReady = function(renderedEl, options)
             }
         }
 
-        if (useSelectorCache && elCacheBySelector[hndl.selector] && !elCacheBySelector[hndl.selector].dirty) {
+        if (useSelectorCache && elCacheBySelector[hndl.selector] != undefined
+            && elCacheBySelector[hndl.selector].length && !elCacheBySelector[hndl.selector].dirty
+        ) {
             benchmarkBox.count('queryCache');
             var els = [];
             for (var j=0; j<elCacheBySelector[hndl.selector].length; j++) {

--- a/tests/Kwc/Advanced/GoogleMapView/Test.php
+++ b/tests/Kwc/Advanced/GoogleMapView/Test.php
@@ -51,7 +51,7 @@ class Kwc_Advanced_GoogleMapView_Test extends Kwc_TestAbstract
         $this->assertContains('<div class="webStandard webForm kwcAbstractComposite kwcAdvancedGoogleMapView kwcAdvancedGoogleMapViewTestComponent">', $html);
 
         $this->assertEquals(1, preg_match('#value="([^"]+)"#', $html, $m));
-        $options = Zend_Json::decode((str_replace("'", '"', Kwf_Util_HtmlSpecialChars::filter_decode($m[1]))));
+        $options = Zend_Json::decode((str_replace("'", '"', Kwf_Util_HtmlSpecialChars::decode($m[1]))));
         $this->assertNotNull($options);
         $this->assertEquals(13, $options['longitude']);
         $this->assertEquals(1, $options['routing']);

--- a/tests/Kwc/Trl/ImageEnlarge/Test.php
+++ b/tests/Kwc/Trl/ImageEnlarge/Test.php
@@ -332,7 +332,7 @@ class Kwc_Trl_ImageEnlarge_Test extends Kwc_TestAbstract
         $this->assertEquals($smallHeight, $smallSrcSize[1]);
 
         preg_match('#data-kwc-lightbox="([^"]*)"#ms', $html, $matches);
-        $lightboxData = json_decode(Kwf_Util_HtmlSpecialChars::filter_decode($matches[1]), true);
+        $lightboxData = json_decode(Kwf_Util_HtmlSpecialChars::decode($matches[1]), true);
 
         $c = Kwf_Component_Data_Root::getInstance()
             ->getPageByUrl('http://'.Kwf_Registry::get('testDomain').str_replace('/kwf/kwctest/'.Kwf_Component_Data_Root::getComponentClass(), '', $lightboxData['lightboxUrl']), '');


### PR DESCRIPTION
If this.config.hideFormOnSuccess is set to true, this.el will be set to display: none; and therefore it has no topoffset anymore. For example, if the form is in the middle of the page and sending via ajax is complete, it will scroll to the top off the page, because topoffset is 0. But what we realy want is to scroll to the top of the form, to see the successmessage.