### PR TITLE
Fix for wrong topoffset on success

### DIFF
--- a/commonjs/frontend-form/form.js
+++ b/commonjs/frontend-form/form.js
@@ -250,9 +250,10 @@ FormComponent.prototype = {
                 }
 
                 var scrollTo = null;
+
                 if (!hasErrors) {
                     // Scroll to top of form
-                    scrollTo = this.el.offset().top;
+                    scrollTo = this.el.parent().offset().top;
                 } else {
                     // Scroll to first error. If there are form-errors those are first
                     if (!r.errorMessages.length) { // there are no form-errors
@@ -269,7 +270,7 @@ FormComponent.prototype = {
                     }
                     if (scrollTo == null) { // no field errors found or only form errors
                         // form-errors are shown at the top of the form
-                        scrollTo = this.el.offset().top;
+                        scrollTo = this.el.parent().offset().top;
                     }
                 }
                 if (scrollTo != null) {


### PR DESCRIPTION
If this.config.hideFormOnSuccess is set to true, this.el will be set to display: none; and therefore it has no topoffset anymore. For example, if the form is in the middle of the page and sending via ajax is complete, it will scroll to the top off the page, because topoffset is 0. But what we realy want is to scroll to the top of the form, to see the successmessage.