### PR TITLE
Forward redirect parameter from registration-form to activation-form

### DIFF
--- a/Kwc/User/Activate/Form/Component.php
+++ b/Kwc/User/Activate/Form/Component.php
@@ -18,6 +18,13 @@ class Kwc_User_Activate_Form_Component extends Kwc_Form_Component
         return $ret;
     }
 
+    protected function _getBaseParams()
+    {
+        $ret = parent::_getBaseParams();
+        if (!empty($_GET['redirect'])) $ret['redirect'] = $_GET['redirect'];
+        return $ret;
+    }
+
     protected function _getErrorMessage($type)
     {
         if ($type == self::ERROR_DATA_NOT_COMPLETE) {

--- a/Kwc/User/Activate/Form/Success/Component.php
+++ b/Kwc/User/Activate/Form/Success/Component.php
@@ -4,17 +4,22 @@ class Kwc_User_Activate_Form_Success_Component extends Kwc_Form_Success_Componen
     public static function getSettings($param = null)
     {
         $ret = parent::getSettings($param);
+        $ret['viewCache'] = false;
         return $ret;
     }
 
     public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer)
     {
         $ret = parent::getTemplateVars($renderer);
+        $redirectUrl = '/';
+        if (isset($_REQUEST['redirect']) && $_REQUEST['redirect']
+            && substr($_REQUEST['redirect'], 0, strlen(Kwf_Setup::getBaseUrl())+1) === Kwf_Setup::getBaseUrl().'/'
+        ) {
+            $redirectUrl = $_REQUEST['redirect'];
+        }
         $ret['config'] = array(
-            'redirectUrl' => '/'
+            'redirectUrl' => $redirectUrl
         );
         return $ret;
     }
-
-
 }

--- a/Kwc/User/Activate/Form/Success/Component.tpl
+++ b/Kwc/User/Activate/Form/Success/Component.tpl
@@ -5,6 +5,9 @@
     </p>
     <p>
         <?=$this->data->trlKwf('You were logged in, automatically')?><br />
-        <a href="/"><?=$this->data->trlKwf('Click here')?></a>, <?=$this->data->trlKwf('to get back to the Startpage')?>.
+        <p>
+            <?=$this->data->trlKwf("If the needed page doesn't load automatically,")?>
+            <?=$this->link($this->config->redirectUrl, $this->data->trlKwf('please click here'))?>.
+        </p>
     </p>
 </div>

--- a/Kwc/User/Register/Form/Component.php
+++ b/Kwc/User/Register/Form/Component.php
@@ -18,6 +18,21 @@ class Kwc_User_Register_Form_Component extends Kwc_Form_Component
         $row->role = $this->_getSetting('standardRole');
     }
 
+    public function _getBaseParams()
+    {
+        $ret = parent::_getBaseParams();
+        if (!empty($_GET['redirect'])) $ret['redirect'] = $_GET['redirect'];
+        return $ret;
+    }
+
+    protected function _beforeInsert(Kwf_Model_Row_Interface $row)
+    {
+        if (isset($_POST['redirect'])) {
+            $row->setRedirectUrl($_POST['redirect']);
+        }
+        parent::_beforeInsert($row);
+    }
+
     protected function _initForm()
     {
         parent::_initForm();

--- a/Kwf/User/EditRow.php
+++ b/Kwf/User/EditRow.php
@@ -11,6 +11,7 @@ class Kwf_User_EditRow extends Kwf_Model_Proxy_Row
     protected $_logChangedUser = false;
     protected $_passwordSet = false;
     private $_sendMails = true; // whether to send mails on saving or not. used for resending emails
+    protected $_redirectUrl = false;
 
     public function __toString()
     {
@@ -21,6 +22,16 @@ class Kwf_User_EditRow extends Kwf_Model_Proxy_Row
         $ret = trim($ret);
         if (!$ret) $ret = $this->email;
         return $ret;
+    }
+
+    public function setRedirectUrl($redirectUrl)
+    {
+        $this->_redirectUrl = $redirectUrl;
+    }
+
+    public function getRedirectUrl()
+    {
+        return $this->_redirectUrl;
     }
 
     public function setNotifyGlobalUserAdded($val)
@@ -257,7 +268,7 @@ class Kwf_User_EditRow extends Kwf_Model_Proxy_Row
     {
         if ($this->_sendMails) {
             $row = $this->getModel()->getKwfUserRowById($this->id);
-            $mail = new Kwf_User_Mail_Activation($row);
+            $mail = new Kwf_User_Mail_Activation($row, $this->getRedirectUrl());
             $mail->send();
             $this->writeLog('user_mail_UserActivation');
         }

--- a/Kwf/User/Mail/Activation.php
+++ b/Kwf/User/Mail/Activation.php
@@ -1,13 +1,13 @@
 <?php
 class Kwf_User_Mail_Activation extends Kwf_User_Mail_Abstract
 {
-    public function __construct(Kwf_Model_Row_Interface $row)
+    public function __construct(Kwf_Model_Row_Interface $row, $redirectUrl = false)
     {
         $tpl = 'UserActivation';
         $subject = Zend_Registry::get('config')->application->name;
         $subject .= ' - '.trlKwf('Useraccount created');
         parent::__construct($tpl, $subject, $row);
 
-        $this->activationUrl = Kwf_Registry::get('userModel')->getUserActivationUrl($row);
+        $this->activationUrl = Kwf_Registry::get('userModel')->getUserActivationUrl($row, $redirectUrl);
     }
 }

--- a/Kwf/User/Model.php
+++ b/Kwf/User/Model.php
@@ -108,7 +108,7 @@ class Kwf_User_Model extends Kwf_Model_RowCache
         return true;
     }
 
-    public function getUserActivationUrl($row)
+    public function getUserActivationUrl($row, $redirectUrl = false)
     {
         $root = Kwf_Component_Data_Root::getInstance();
         $activateComponent = null;
@@ -128,7 +128,13 @@ class Kwf_User_Model extends Kwf_Model_RowCache
         }
         $activateUrl = (Kwf_Util_Https::domainSupportsHttps($host) ? 'https' : 'http') . '://'.$host.Kwf_Setup::getBaseUrl().'/kwf/user/login/activate';
         if ($activateComponent) $activateUrl = $activateComponent->getAbsoluteUrl();
-        return $activateUrl.'?code='.$row->id.'-'.$row->generateActivationToken(Kwf_User_Auth_Interface_Activation::TYPE_ACTIVATE);
+        $params = array(
+            'code' => $row->id.'-'.$row->generateActivationToken(Kwf_User_Auth_Interface_Activation::TYPE_ACTIVATE)
+        );
+        if ($redirectUrl) {
+            $params['redirect'] = $redirectUrl;
+        }
+        return $activateUrl.'?'.http_build_query($params);
     }
 
     public function getUserLostPasswordUrl($row)


### PR DESCRIPTION
This ways it's possible to allow to continue where the user started.
RedirectUrl forward is implemented like in login-form.
RedirectUrl has to be set in User_EditRow because sendActivationMail is
called in save() function of User_EditRow and not directly in registration
component. It also needs to be an additional parameter for
Kwf_User_Mail_Activation because $row is no User_EditRow and does not have
the redirectUrl field.