### PR TITLE
Add setting to stop playing the video after it was hide and reshowed

### DIFF
--- a/Kwc/Advanced/Youtube/Component.defer.js
+++ b/Kwc/Advanced/Youtube/Component.defer.js
@@ -13,8 +13,11 @@ onReady.onHide('.kwcClass .kwcBem__youtubePlayer', function(el) {
 onReady.onShow('.kwcClass .kwcBem__youtubePlayer', function(el) {
     var kwcAdvancedYoutube = el.closest('.kwcClass');
     var config = kwcAdvancedYoutube.data('config');
-    if (kwcAdvancedYoutube.data('player')) {
-        if (config.playerVars.autoplay) kwcAdvancedYoutube.data('player').playVideo();
+    var player = kwcAdvancedYoutube.data('player');
+    if (player && config.playerVars.autoplay) {
+        if (config.resumeOnShow || player.getPlayerState() != 2) {
+            player.playVideo();
+        }
     }
 }, {defer: true});
 

--- a/Kwc/Advanced/Youtube/Component.php
+++ b/Kwc/Advanced/Youtube/Component.php
@@ -72,7 +72,8 @@ class Kwc_Advanced_Youtube_Component extends Kwc_Abstract_Composite_Component
             'size' => $row->size,
             'width' => $width,
             'height' => null,
-            'ratio' => '16x9'
+            'ratio' => '16x9',
+            'resumeOnShow' => true //True is set because the behavior was like that before this option was added
         );
         if ($d = $row->dimensions) {
             if ($d == '16x9') {


### PR DESCRIPTION
I created the pull request on behalf of @mike-tuxedo because his github account is currently locked.

The problem is that it doesn't always make sense to continue a paused youtube-video when showing it after it was hidden before. If the video is in a lightbox it may be a favored behaviour when the video is resumed but in our case there is a slider with severals videos in several tabs and the current behaviour causes all stopped videos to play simultanely when reactivating a tab.