### PR TITLE
load es6-promise polyfill by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
             "JSONStream": "~1.0.4",
             "modernizr": "^3.0.0",
             "postcss": "~5.0.13",
-            "es6-promise": "~3.0.2",
+            "es6-promise": "^4.1.1",
             "css-selectors-count": "~1.0.1",
             "postcss-chunk": "git://github.com/koala-framework/postcss-chunk.git#1b5a343cd4017d5608ece9f5f7a702f4db821171",
             "autoprefixer": "~6.1.0",

--- a/node_modules_build/kwf-webpack/config/webpack.kwc.config.js
+++ b/node_modules_build/kwf-webpack/config/webpack.kwc.config.js
@@ -22,6 +22,7 @@ let entry = {
 Object.keys(componentAssets).forEach(pkg => {
     if (pkg == 'Frontend') {
         entry.Frontend = [
+            'es6-promise',
             require.resolve('../loader/ini-loader')+'?dep=Frontend!',
         ];
         if (kwfConfig['webpack-dev-server-url'] && devBuild) {


### PR DESCRIPTION
webpack build adds generated promise code in deps and this crashes in ie11