### PR TITLE
Call the hide-event on previous active tab, when active tab changed

### DIFF
--- a/Kwf_js/EyeCandy/Tabs/Tabs.js
+++ b/Kwf_js/EyeCandy/Tabs/Tabs.js
@@ -117,6 +117,7 @@ Tabs.prototype = {
                 complete: function() {
                     oldContentEl.css('position', 'static');
                     oldContentEl.removeClass('kwfUp-kwfTabsContentActive');
+                    onReady.callOnContentReady(oldContentEl, {action: 'hide'});
                     newContentEl.css('position', 'static');
                     newContentEl.show();
                     newContentEl.css('height', 'auto');


### PR DESCRIPTION
When the active tab changes, the content of the tab wish was previous active will be hided. For that content, our standard "hide"-event has to be fired.