### PR TITLE
Login formOptions are html and need to be raw in twig to work.

### DIFF
--- a/Kwc/User/Login/Component.twig
+++ b/Kwc/User/Login/Component.twig
@@ -19,7 +19,7 @@
                     <form method="GET" action="{{ r.url|escape }}">
                     <input type="hidden" name="redirectAuth" value="{{ r.authMethod|escape }}" />
                     <input type="hidden" name="redirect" value="{{ r.redirect|escape }}" />
-                    {{ r.formOptions }}
+                    {{ r.formOptions|raw }}
                     <div class="button {{ r.authMethod}}">
                         <button class="{{ r.authMethod}}">
                             {% if r.icon %}


### PR DESCRIPTION
This field should be renamed to formOptionsHtml, but this would be
an incompatible change and shouldn't be done in a stable branch.