### PR TITLE
Fix Mails when using preliminaryDomain

### DIFF
--- a/Kwc/Mail/Abstract/Component.php
+++ b/Kwc/Mail/Abstract/Component.php
@@ -110,7 +110,7 @@ abstract class Kwc_Mail_Abstract_Component extends Kwc_Abstract
             $format == Kwc_Mail_Recipient_Interface::MAIL_FORMAT_HTML)
         {
             $html = $this->getHtml($recipient, $addViewTracker);
-            $mail->setDomain($this->getData()->getDomain());
+            $mail->setDomain($this->getData()->getDomainPreliminary());
             $mail->setAttachImages($this->_getSetting('attachImages'));
             $mail->setBodyHtml($html);
         }

--- a/Kwc/Mail/Redirect/Component.php
+++ b/Kwc/Mail/Redirect/Component.php
@@ -251,7 +251,7 @@ class Kwc_Mail_Redirect_Component extends Kwc_Abstract
 
     protected function _createHashedRedirectUrl(array $parameters)
     {
-        return $this->getData()->getAbsoluteUrl().'?d='
+        return $this->getData()->getAbsoluteUrlPreliminary().'?d='
             .implode('_', $parameters)
             .'_'.$this->_createRedirectHash($parameters);
     }

--- a/Kwf/Component/Data.php
+++ b/Kwf/Component/Data.php
@@ -214,20 +214,43 @@ class Kwf_Component_Data
     }
 
     /**
+     * Returns preliminary domain (if set) or domain for current component
+     *
+     * @return string
+     */
+    public function getDomainPreliminary()
+    {
+        if ($domain = $this->getBaseProperty('preliminaryDomain')) {
+            return $domain;
+        } else {
+            return $this->getDomain();
+        }
+    }
+
+    /**
+     * Returns absolute url including domain and protocoal using preliminary domain (if set) or domain for current component
+     *
+     * @return string
+     */
+    public function getAbsoluteUrlPreliminary()
+    {
+        if ($domain = $this->getBaseProperty('preliminaryDomain')) {
+            $https = Kwf_Util_Https::domainSupportsHttps($domain);
+            $protocol = $https ? 'https' : 'http';
+            return $protocol . '://'.$domain.$this->url;
+        } else {
+            return $this->getAbsoluteUrl();
+        }
+    }
+
+    /**
      * Returns preview url
      *
      * @return string
      */
     public function getPreviewUrl()
     {
-        if ($domain = $this->getBaseProperty('preliminaryDomain')) {
-            $https = Kwf_Util_Https::domainSupportsHttps($domain);
-            $protocol = $https ? 'https' : 'http';
-            $url = $protocol . '://'.$domain.$this->url;
-        } else {
-            $url = $this->getAbsoluteUrl();
-        }
-        return Kwf_Setup::getBaseUrl().'/admin/component/preview/?url='.urlencode($url.'?kwcPreview');
+        return Kwf_Setup::getBaseUrl().'/admin/component/preview/?url='.urlencode($this->getAbsoluteUrlPreliminary().'?kwcPreview');
     }
 
     public function __get($var)


### PR DESCRIPTION
Mails obviously need to have absolute urls, when preliminaryDomain is set server.domain is usually not yet online.
This changes mails to use preliminaryDomain if one is set.

Caches should be no issue because the link replacement is not cached (as it has to be done for every use) and the img replacement
is also not cached as it is the last step.