### PR TITLE
Replace kwfLocal, begin with lower-case letter

### DIFF
--- a/node_modules_build/kwf-webpack/loader/kwfup-loader.js
+++ b/node_modules_build/kwf-webpack/loader/kwfup-loader.js
@@ -29,6 +29,7 @@ module.exports = function(source, map) {
             return m.toUpperCase();
         });
         p = p.replace(/\//g, '');
+        p = p.charAt(0).toLowerCase() + p.substr(1);
 
         p = r + p;
         source = source.replace(/kwfLocal/g, p);


### PR DESCRIPTION
In order to target classes generated by a react application from component.scss,
the class name needs to start with a lower-case letter. kwcClass and kwcBem
start with lower-case letter as well.