### PR TITLE
NonAjax Form instead of Form

### DIFF
--- a/Kwc/FulltextSearch/Search/ViewAjax/SearchForm/Component.php
+++ b/Kwc/FulltextSearch/Search/ViewAjax/SearchForm/Component.php
@@ -1,10 +1,9 @@
 <?php
-class Kwc_FulltextSearch_Search_ViewAjax_SearchForm_Component extends Kwc_Form_Component
+class Kwc_FulltextSearch_Search_ViewAjax_SearchForm_Component extends Kwc_Form_NonAjax_Component
 {
     public static function getSettings($param = null)
     {
         $ret = parent::getSettings($param);
-        $ret['useAjaxRequest'] = false;
         $ret['method'] = 'get';
         $ret['generators']['child']['component']['success'] = false;
         $ret['rootElementClass'] = 'unResponsive';


### PR DESCRIPTION
Extend Kwc_Form_NonAjax_Component because FulltextSearch uses removed functions of Kwc_Form_Component