### PR TITLE
Enable webpack build to support local https (without certificate)

### DIFF
--- a/Kwc/Basic/Text/StylesModel.php
+++ b/Kwc/Basic/Text/StylesModel.php
@@ -45,7 +45,15 @@ class Kwc_Basic_Text_StylesModel extends Kwf_Model_Db_Proxy
         } else {
             $filename = 'build/assets/Frontend.css';
         }
-        return self::parseMasterStyles(file_get_contents($filename));
+        $fileGetContentsContextOptions = array();
+        if (Kwf_Config::getValue('server.https') && Kwf_Config::getValue('debug.webpackDevServer')) {
+            $fileGetContentsContextOptions["ssl"] = array(
+                "verify_peer" => false,
+                "verify_peer_name" => false
+            );
+        }
+
+        return self::parseMasterStyles(file_get_contents($filename, false, stream_context_create($fileGetContentsContextOptions)));
     }
 
     public function getStyles($ownStyles = false)

--- a/Kwf/Assets/WebpackConfig.php
+++ b/Kwf/Assets/WebpackConfig.php
@@ -54,7 +54,8 @@ class Kwf_Assets_WebpackConfig
         if ($url = Kwf_Config::getValue('debug.webpackDevServerUrl')) {
             return $url;
         } else {
-            return 'http://'.self::getDevServerPublic().'/';
+            $protocol = Kwf_Config::getValue('server.https') ? 'https://' : 'http://';
+            return $protocol.self::getDevServerPublic().'/';
         }
     }
 }

--- a/Kwf/Controller/Action/Cli/Web/ClearCacheWatcherController.php
+++ b/Kwf/Controller/Action/Cli/Web/ClearCacheWatcherController.php
@@ -18,6 +18,9 @@ class Kwf_Controller_Action_Cli_Web_ClearCacheWatcherController extends Kwf_Cont
         if (Kwf_Assets_WebpackConfig::getDevServerPublic()) {
             $cmd .= " --public=".Kwf_Assets_WebpackConfig::getDevServerPublic();
         }
+        if (Kwf_Config::getValue('server.https')) {
+            $cmd .= " --https";
+        }
         echo $cmd."\n";
 
         $process = new Process($cmd);

--- a/Kwf/Util/Build/Types/Assets.php
+++ b/Kwf/Util/Build/Types/Assets.php
@@ -74,6 +74,9 @@ class Kwf_Util_Build_Types_Assets extends Kwf_Util_Build_Types_Abstract
     {
         $cmd = 'NODE_PATH=vendor/koala-framework/koala-framework/node_modules_build ./vendor/bin/node  node_modules/.bin/webpack --colors';
         if (!isset($_SERVER['NO_PROGRESS'])) $cmd .= ' --progress';
+        if (Kwf_Config::getValue('server.https')) {
+            $cmd .= ' --https';
+        }
         passthru($cmd, $retVal);
         if ($retVal) {
             throw new Kwf_Exception("webpack failed");

--- a/Kwf/View/Helper/Assets.php
+++ b/Kwf/View/Helper/Assets.php
@@ -25,7 +25,8 @@ class Kwf_View_Helper_Assets
                 if (!$isRunning) {
                     throw new Kwf_Exception("webpack-dev-server not running, please start clear-cache-watcher");
                 }
-                $webpackUrl = 'http://localhost:'.Kwf_Assets_WebpackConfig::getDevServerPort();
+                $protocol = Kwf_Config::getValue('server.https') ? 'https://' : 'http://';
+                $webpackUrl = $protocol.'localhost:'.Kwf_Assets_WebpackConfig::getDevServerPort();
             }
         }
 
@@ -36,7 +37,15 @@ class Kwf_View_Helper_Assets
             $htmlFile = 'build/assets/'.$assetsPackage.'.'.$language.'.html';
         }
 
-        $c = file_get_contents($htmlFile);
+        $fileGetContentsContextOptions = array();
+        if (Kwf_Config::getValue('server.https') && Kwf_Config::getValue('debug.webpackDevServer')) {
+            $fileGetContentsContextOptions["ssl"] = array(
+                "verify_peer" => false,
+                "verify_peer_name" => false
+            );
+        }
+
+        $c = file_get_contents($htmlFile, false, stream_context_create($fileGetContentsContextOptions));
 
         $c = preg_replace('#</?head>#', '', $c);
         $c = str_replace('/assets/build/./', '/assets/build/', $c);


### PR DESCRIPTION
as this is needed to test several integrations of kwf-webs in
external systems.