### PR TITLE
Remove default styling

### DIFF
--- a/Kwc/Shop/Cart/Checkout/Form/Component.css
+++ b/Kwc/Shop/Cart/Checkout/Form/Component.css
@@ -1,8 +1,0 @@
-.kwcClass label { width: 140px; }
-.kwcClass .kwfFormFieldRadioHorizontal label { float: none; margin-left: 0px; }
-.ext-ie7 .kwcClass .kwfFormFieldRadioHorizontal label { position: relative; top: -5px; }
-.ext-ie7 .kwcClass .kwfFormFieldRadioHorizontal span { margin-left: -13px; }
-.kwcClass .kwfFormFieldRadioHorizontal input { margin-left: 0px; }
-.kwcClass .kwfFormFieldTextField input,
-.kwcClass .kwfFormFieldTextArea textarea { width: 300px; }
-.kwcClass p.formText { margin: 5px 0px; }


### PR DESCRIPTION
Defaultsryling makes no sense for a shop that is used in different webs and it's annoying to override it every time.