### PR TITLE
Use ajax to submit checkoutform

### DIFF
--- a/Kwc/Shop/Cart/Checkout/Form/Component.php
+++ b/Kwc/Shop/Cart/Checkout/Form/Component.php
@@ -1,5 +1,5 @@
 <?php
-class Kwc_Shop_Cart_Checkout_Form_Component extends Kwc_Form_NonAjax_Component
+class Kwc_Shop_Cart_Checkout_Form_Component extends Kwc_Form_Component
 {
     public static function getSettings($param = null)
     {

--- a/Kwc/Shop/Cart/Checkout/Form/Success/Component.php
+++ b/Kwc/Shop/Cart/Checkout/Form/Success/Component.php
@@ -11,7 +11,7 @@ class Kwc_Shop_Cart_Checkout_Form_Success_Component extends Kwc_Abstract
     public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer)
     {
         $ret = parent::getTemplateVars($renderer);
-        $row = $this->getData()->parent->getComponent()->getFormRow();
+        $row = $this->getData()->parent->getComponent()->getForm()->getRow();
         $ret['payment'] = $this->getData()->parent->parent->getComponent()->getPayment($row);
         return $ret;
     }


### PR DESCRIPTION
Send form per ajax is needed to place the errormessages under the respective input field.