### PR TITLE
Add events for directory view when source directory changes

### DIFF
--- a/Kwc/Directories/Item/Directory/Cc/Events.php
+++ b/Kwc/Directories/Item/Directory/Cc/Events.php
@@ -53,7 +53,7 @@ class Kwc_Directories_Item_Directory_Cc_Events extends Kwc_Abstract_Composite_Cc
 
     public function onMasterChildModelUpdated(Kwc_Directories_List_EventItemsUpdated $event)
     {
-        $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class));
+        $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class, $event->subroot));
     }
 
 }

--- a/Kwc/Directories/Item/Directory/Trl/Events.php
+++ b/Kwc/Directories/Item/Directory/Trl/Events.php
@@ -79,7 +79,7 @@ class Kwc_Directories_Item_Directory_Trl_Events extends Kwc_Chained_Trl_Events
 
     public function onMasterChildModelUpdated(Kwc_Directories_List_EventItemsUpdated $event)
     {
-        $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class));
+        $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class, $event->subroot));
     }
 
     // trl model (optional)
@@ -113,6 +113,6 @@ class Kwc_Directories_Item_Directory_Trl_Events extends Kwc_Chained_Trl_Events
 
     public function onChildModelUpdated(Kwf_Events_Event_Model_Updated $event)
     {
-        $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class));
+        $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class, $event->subroot));
     }
 }

--- a/Kwc/Directories/List/EventAbstract.php
+++ b/Kwc/Directories/List/EventAbstract.php
@@ -1,0 +1,10 @@
+<?php
+abstract class Kwc_Directories_List_EventAbstract extends Kwf_Events_Event_Abstract
+{
+    public $subroot;
+    public function __construct($class, $subroot = null)
+    {
+        parent::__construct($class);
+        $this->subroot = $subroot;
+    }
+}

--- a/Kwc/Directories/List/EventDirectoryChanged.php
+++ b/Kwc/Directories/List/EventDirectoryChanged.php
@@ -1,4 +1,4 @@
 <?php
-class Kwc_Directories_List_EventDirectoryChanged extends Kwf_Events_Event_Abstract
+class Kwc_Directories_List_EventDirectoryChanged extends Kwc_Directories_List_EventAbstract
 {
 }

--- a/Kwc/Directories/List/EventDirectoryChanged.php
+++ b/Kwc/Directories/List/EventDirectoryChanged.php
@@ -1,0 +1,4 @@
+<?php
+class Kwc_Directories_List_EventDirectoryChanged extends Kwf_Events_Event_Abstract
+{
+}

--- a/Kwc/Directories/List/EventItemAbstract.php
+++ b/Kwc/Directories/List/EventItemAbstract.php
@@ -1,12 +1,10 @@
 <?php
-class Kwc_Directories_List_EventItemAbstract extends Kwf_Events_Event_Abstract
+class Kwc_Directories_List_EventItemAbstract extends Kwc_Directories_List_EventAbstract
 {
     public $itemId;
-    public $subroot;
     public function __construct($class, $itemId, $subroot)
     {
-        parent::__construct($class);
+        parent::__construct($class, $subroot);
         $this->itemId = $itemId;
-        $this->subroot = $subroot;
     }
 }

--- a/Kwc/Directories/List/EventItemsUpdated.php
+++ b/Kwc/Directories/List/EventItemsUpdated.php
@@ -1,4 +1,4 @@
 <?php
-class Kwc_Directories_List_EventItemsUpdated extends Kwf_Events_Event_Abstract
+class Kwc_Directories_List_EventItemsUpdated extends Kwc_Directories_List_EventAbstract
 {
 }

--- a/Kwc/Directories/List/View/Events.php
+++ b/Kwc/Directories/List/View/Events.php
@@ -59,6 +59,11 @@ class Kwc_Directories_List_View_Events extends Kwc_Abstract_Events
                             'callback' => 'onDirectoryModelUpdate'
                         );
                     }
+                    $ret[] = array(
+                        'class' => $class,
+                        'event' => 'Kwc_Directories_List_EventDirectoryChanged',
+                        'callback' => 'onDirectoryChanged'
+                    );
                 }
             }
         }
@@ -177,6 +182,13 @@ class Kwc_Directories_List_View_Events extends Kwc_Abstract_Events
     }
 
     public function onDirectoryModelUpdate(Kwc_Directories_List_EventItemsUpdated $event)
+    {
+        $this->fireEvent(new Kwf_Component_Event_ComponentClass_ContentChanged($this->_class));
+        $this->fireEvent(new Kwf_Component_Event_ComponentClass_AllPartialChanged($this->_class));
+        $this->fireEvent(new Kwf_Component_Event_ComponentClass_PartialsChanged($this->_class));
+    }
+
+    public function onDirectoryChanged(Kwc_Directories_List_EventDirectoryChanged $event)
     {
         $this->fireEvent(new Kwf_Component_Event_ComponentClass_ContentChanged($this->_class));
         $this->fireEvent(new Kwf_Component_Event_ComponentClass_AllPartialChanged($this->_class));

--- a/Kwc/Directories/List/View/Events.php
+++ b/Kwc/Directories/List/View/Events.php
@@ -56,13 +56,13 @@ class Kwc_Directories_List_View_Events extends Kwc_Abstract_Events
                         $ret[] = array(
                             'class' => $directoryClass,
                             'event' => 'Kwc_Directories_List_EventItemsUpdated',
-                            'callback' => 'onDirectoryModelUpdate'
+                            'callback' => 'onDirectoryUpdate'
                         );
                     }
                     $ret[] = array(
                         'class' => $class,
                         'event' => 'Kwc_Directories_List_EventDirectoryChanged',
-                        'callback' => 'onDirectoryChanged'
+                        'callback' => 'onDirectoryUpdate'
                     );
                 }
             }
@@ -181,14 +181,7 @@ class Kwc_Directories_List_View_Events extends Kwc_Abstract_Events
         }
     }
 
-    public function onDirectoryModelUpdate(Kwc_Directories_List_EventItemsUpdated $event)
-    {
-        $this->fireEvent(new Kwf_Component_Event_ComponentClass_ContentChanged($this->_class));
-        $this->fireEvent(new Kwf_Component_Event_ComponentClass_AllPartialChanged($this->_class));
-        $this->fireEvent(new Kwf_Component_Event_ComponentClass_PartialsChanged($this->_class));
-    }
-
-    public function onDirectoryChanged(Kwc_Directories_List_EventDirectoryChanged $event)
+    public function onDirectoryUpdate(Kwc_Directories_List_EventAbstract $event)
     {
         $this->fireEvent(new Kwf_Component_Event_ComponentClass_ContentChanged($this->_class, $event->subroot));
         $this->fireEvent(new Kwf_Component_Event_ComponentClass_AllPartialChanged($this->_class, $event->subroot));

--- a/Kwc/Directories/List/View/Events.php
+++ b/Kwc/Directories/List/View/Events.php
@@ -190,8 +190,8 @@ class Kwc_Directories_List_View_Events extends Kwc_Abstract_Events
 
     public function onDirectoryChanged(Kwc_Directories_List_EventDirectoryChanged $event)
     {
-        $this->fireEvent(new Kwf_Component_Event_ComponentClass_ContentChanged($this->_class));
-        $this->fireEvent(new Kwf_Component_Event_ComponentClass_AllPartialChanged($this->_class));
-        $this->fireEvent(new Kwf_Component_Event_ComponentClass_PartialsChanged($this->_class));
+        $this->fireEvent(new Kwf_Component_Event_ComponentClass_ContentChanged($this->_class, $event->subroot));
+        $this->fireEvent(new Kwf_Component_Event_ComponentClass_AllPartialChanged($this->_class, $event->subroot));
+        $this->fireEvent(new Kwf_Component_Event_ComponentClass_PartialsChanged($this->_class, $event->subroot));
     }
 }

--- a/Kwc/Directories/TopChoose/Events.php
+++ b/Kwc/Directories/TopChoose/Events.php
@@ -1,0 +1,26 @@
+<?php
+class Kwc_Directories_TopChoose_Events extends Kwc_Abstract_Events
+{
+    public function getListeners()
+    {
+        $ret = parent::getListeners();
+        $ret[] = array(
+            'class' => 'Kwc_Directories_TopChoose_Model',
+            'event' => 'Kwf_Events_Event_Row_Updated',
+            'callback' => 'onRowUpdated'
+        );
+        return $ret;
+    }
+
+    public function onRowUpdated(Kwf_Events_Event_Row_Updated $event)
+    {
+        $this->fireEvent(new Kwc_Directories_List_EventDirectoryChanged($this->_class));
+        /*
+        foreach (Kwf_Component_Data_Root::getInstance()->getComponentsByDbId($event->row->component_id) as $component) {
+            foreach (Kwc_Directories_TopChoose_Component::getItemDirectoryClasses($component->componentClass) as $class) {
+                $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class));
+            }
+        };
+        */
+    }
+}

--- a/Kwc/Directories/TopChoose/Events.php
+++ b/Kwc/Directories/TopChoose/Events.php
@@ -15,7 +15,11 @@ class Kwc_Directories_TopChoose_Events extends Kwc_Abstract_Events
     public function onRowUpdated(Kwf_Events_Event_Row_Updated $event)
     {
         if ($event->isDirty('directory_component_id')) {
-            $this->fireEvent(new Kwc_Directories_List_EventDirectoryChanged($this->_class));
+            $subroots = Kwf_Component_Data_Root::getInstance()
+                ->getComponentsByDbId($event->row->directory_component_id);
+            foreach ($subroots as $subroot) {
+                $this->fireEvent(new Kwc_Directories_List_EventDirectoryChanged($this->_class, $subroot));
+            }
         }
     }
 }

--- a/Kwc/Directories/TopChoose/Events.php
+++ b/Kwc/Directories/TopChoose/Events.php
@@ -14,13 +14,8 @@ class Kwc_Directories_TopChoose_Events extends Kwc_Abstract_Events
 
     public function onRowUpdated(Kwf_Events_Event_Row_Updated $event)
     {
-        $this->fireEvent(new Kwc_Directories_List_EventDirectoryChanged($this->_class));
-        /*
-        foreach (Kwf_Component_Data_Root::getInstance()->getComponentsByDbId($event->row->component_id) as $component) {
-            foreach (Kwc_Directories_TopChoose_Component::getItemDirectoryClasses($component->componentClass) as $class) {
-                $this->fireEvent(new Kwc_Directories_List_EventItemsUpdated($this->_class));
-            }
-        };
-        */
+        if ($event->isDirty('directory_component_id')) {
+            $this->fireEvent(new Kwc_Directories_List_EventDirectoryChanged($this->_class));
+        }
     }
 }


### PR DESCRIPTION
When source directory is changed in TopChoose the cache for the directory view has to be deleted
Overwriting the view for TopChoose should be avoided so we had to add a generic event to the
directory view which listens for the directory-class and not for the item-directory-class.