### PR TITLE
Render a link-tag instead of a componentLink

### DIFF
--- a/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/Abstract/Mail.html.twig
+++ b/Kwc/Newsletter/Detail/Mail/Paragraphs/LinkTag/Abstract/Mail.html.twig
@@ -1,1 +1,5 @@
-{{ renderer.componentLink(target) }}
+{% if target.url %}
+    <a href="{{ target.url }}">
+{% else %}
+    <a>
+{% endif %}


### PR DESCRIPTION
Previously the componentLink would render a link that would use
the componentName of the target as the link text.