### PR TITLE
Convert tpl to twig for Kwc_Basic_Space_Component

### DIFF
--- a/Kwc/Basic/Space/Component.css
+++ b/Kwc/Basic/Space/Component.css
@@ -1,1 +1,0 @@
-.kwcClass {  }

--- a/Kwc/Basic/Space/Component.tpl
+++ b/Kwc/Basic/Space/Component.tpl
@@ -1,1 +1,0 @@
-<div class="<?=$this->rootElementClass?>" style="height: <?= $this->height ?>px;"></div>

--- a/Kwc/Basic/Space/Component.twig
+++ b/Kwc/Basic/Space/Component.twig
@@ -1,0 +1,1 @@
+<div class="{{ rootElementClass }}" style="height: {{ height }}px;"></div>

--- a/Kwc/Basic/Space/Mail.html.tpl
+++ b/Kwc/Basic/Space/Mail.html.tpl
@@ -1,5 +1,0 @@
-<table width="100%" cellspacing="0" cellpadding="0">
-    <tr>
-        <td height="<?=$this->height;?>"></td>
-    </tr>
-</table>

--- a/Kwc/Basic/Space/Mail.html.twig
+++ b/Kwc/Basic/Space/Mail.html.twig
@@ -1,0 +1,5 @@
+<table width="100%" cellspacing="0" cellpadding="0">
+    <tr>
+        <td height="{{ height }}" style="font-size: {{ height }}px; line-height: {{ height }}px;">&nbsp;</td>
+    </tr>
+</table>

--- a/Kwc/Basic/Space/Mail.txt.tpl
+++ b/Kwc/Basic/Space/Mail.txt.tpl
@@ -1,5 +1,0 @@
-<?php
-for ($i=0; $i<floor($this->height / 15); $i++) {
-    echo "\n";
-}
-?>

--- a/Kwc/Basic/Space/Mail.txt.twig
+++ b/Kwc/Basic/Space/Mail.txt.twig
@@ -1,0 +1,3 @@
+{% for h in 0..(height / 15)|round %}
+
+{% endfor %}


### PR DESCRIPTION
Some versions of Outlook do not recognize the height attribute,
so the font-size and line-height styles were added.
See: [https://www.campaignmonitor.com/blog/email-marketing/2012/08/outlook-2013-says-no-to-empty-table-cells/](https://www.campaignmonitor.com/blog/email-marketing/2012/08/outlook-2013-says-no-to-empty-table-cells/)

Also remove the unnecessary css file.