### PR TITLE
removed check in newsletter send action for recipients who are not ac…

### DIFF
--- a/Kwc/Newsletter/Detail/Mail/Component.php
+++ b/Kwc/Newsletter/Detail/Mail/Component.php
@@ -68,9 +68,6 @@ class Kwc_Newsletter_Detail_Mail_Component extends Kwc_Mail_Component
             $recipient->getMailUnsubscribe()) {
             $ret = false;
 
-        } else if ($recipient instanceof Kwf_Model_Row_Abstract &&
-            $recipient->hasColumn('activated') && !$recipient->activated) {
-            $ret = false;
         }
         return $ret;
     }


### PR DESCRIPTION
…tivated

the importToQueue function has also a check that only activated recipients can be added, so this is not necessary
now its possible to build a CUSTOM newsletter for non activated recipients