### PR TITLE
Fix missing function in directory_list_trl component

### DIFF
--- a/Kwc/Directories/List/Trl/Component.php
+++ b/Kwc/Directories/List/Trl/Component.php
@@ -38,6 +38,16 @@ class Kwc_Directories_List_Trl_Component extends Kwc_Abstract_Composite_Trl_Comp
         );
     }
 
+    public function getItems($select = null)
+    {
+        $ret = array();
+        $items = $this->getData()->chained->getComponent()->getItems($select);
+        foreach ($items as $item) {
+            $ret[] = self::getChainedByMaster($item, $this->getData());
+        }
+        return $ret;
+    }
+
     public function getSelect()
     {
         $itemDirectory = $this->getItemDirectory();


### PR DESCRIPTION
Somehow this function is called (after kwf 3.7)but wasn't existing