### PR TITLE
Fix backend activation with single redirect-auth method

### DIFF
--- a/Kwf/Controller/Action/User/BackendActivateController.php
+++ b/Kwf/Controller/Action/User/BackendActivateController.php
@@ -100,9 +100,7 @@ class Kwf_Controller_Action_User_BackendActivateController extends Kwf_Controlle
                 );
             }
         }
-        if (count($this->view->redirects) == 1 && !$showPassword) {
-            $this->redirect($this->view->redirects[0]['url'], array('prependBase'=>false));
-        } else if (count($this->view->redirects) == 0 && $showPassword) {
+        if (count($this->view->redirects) == 0 && $showPassword) {
             $this->redirect($this->view->passwordUrl, array('prependBase'=>false));
         }
     }


### PR DESCRIPTION
redirect missed parameters like authMethod and code. As this is
also a security problem this feature is removed.