### PR TITLE
when tag is suggested, show this only when it is accepted

### DIFF
--- a/Kwc/Tags/Component.php
+++ b/Kwc/Tags/Component.php
@@ -22,6 +22,11 @@ class Kwc_Tags_Component extends Kwc_Abstract_Composite_Component
         $select->expr('tag_name');
         $ret['tags'] = array();
         foreach ($model->getRows($select) as $tag) {
+            if ($tag->countChildRows('Suggestions') > 0) {
+                $suggestion = $tag->getChildRows('Suggestions')->current();
+                if ($suggestion->status != 'accepted') continue;
+            }
+
             $ret['tags'][] = $tag->tag_name;
         }
         $ret['headline'] = $this->getData()->trlStaticExecute($this->_getSetting('componentName'));

--- a/Kwc/Tags/ComponentToTag.php
+++ b/Kwc/Tags/ComponentToTag.php
@@ -7,6 +7,9 @@ class Kwc_Tags_ComponentToTag extends Kwf_Model_Db
         'Tag' => 'tag_id->Kwc_Tags_Model',
         'Component' => 'component_id->Kwc_Tags_ComponentModel'
     );
+    protected $_dependentModels = array(
+        'Suggestions' => 'Kwc_Tags_Suggestions_Model'
+    );
 
     protected function _init()
     {

--- a/Kwc/Tags/Events.php
+++ b/Kwc/Tags/Events.php
@@ -14,6 +14,11 @@ class Kwc_Tags_Events extends Kwc_Abstract_Events
             'event' => 'Kwf_Component_Event_Row_Deleted',
             'callback' => 'onTagRowUpdate'
         );
+        $ret[] = array(
+            'class' => 'Kwc_Tags_Suggestions_Model',
+            'event' => 'Kwf_Component_Event_Row_Updated',
+            'callback' => 'onTagRowUpdate'
+        );
         return $ret;
     }
 

--- a/Kwc/Tags/Suggestions/Controller.php
+++ b/Kwc/Tags/Suggestions/Controller.php
@@ -51,6 +51,11 @@ class Kwc_Tags_Suggestions_Controller extends Kwf_Controller_Action
         $select->whereEquals('component_id', $componentId);
         $this->view->tags = array();
         foreach ($componentToTagModel->getRows($select) as $tag) {
+            if ($tag->countChildRows('Suggestions') > 0) {
+                $suggestion = $tag->getChildRows('Suggestions')->current();
+                if ($suggestion->status != 'accepted') continue;
+            }
+
             $this->view->tags[] = $tag->tag_name;
         }
         $this->view->tags = implode(', ', $this->view->tags);

--- a/Kwc/Tags/Suggestions/Model.php
+++ b/Kwc/Tags/Suggestions/Model.php
@@ -11,6 +11,7 @@ class Kwc_Tags_Suggestions_Model extends Kwf_Model_Db
     {
         parent::_init();
         $this->_referenceMap['User'] = 'user_id->' . Kwf_Registry::get('config')->user->model;
+        $this->_exprs['component_id'] = new Kwf_Model_Select_Expr_Parent('ComponentToTag', 'component_id');
         $this->_exprs['tag_count_used'] = new Kwf_Model_Select_Expr_Parent('ComponentToTag', 'tag_count_used');
         $this->_exprs['tag_name'] = new Kwf_Model_Select_Expr_Parent('ComponentToTag', 'tag_name');
         $this->_exprs['user_email'] = new Kwf_Model_Select_Expr_Parent('User', 'email');


### PR DESCRIPTION
Has originally been fixed in 3.7 (ba72df8f62d8a4aaba2da080afb7b63f5cca6f2b) but is also needed in older webs so I cherry-picked the commit.