### PR TITLE
Add matchChildUrls generator flag that allows a component to 'eat' alll child urls

### DIFF
--- a/Kwc/Root/Abstract.php
+++ b/Kwc/Root/Abstract.php
@@ -65,6 +65,27 @@ class Kwc_Root_Abstract extends Kwc_Abstract implements Kwf_Util_Maintenance_Job
                     if ($ret) return $ret;
                 }
             }
+
+            $matchChildUrlPageFilenames = Kwf_Cache_SimpleStatic::fetch('matchChildUrlPageFilenames');
+            if ($matchChildUrlPageFilenames === false) {
+                $matchChildUrlPages = $component->getChildComponents(array(
+                    'page' => true,
+                    'static' => true,
+                    'generatorFlags' => array(
+                        'matchChildUrls' => true
+                    )
+                ));
+                $matchChildUrlPageFilenames = array();
+                foreach ($matchChildUrlPages as $p) {
+                    $matchChildUrlPageFilenames[$p->filename] = $p->componentId;
+                }
+                Kwf_Cache_SimpleStatic::add('matchChildUrlPageFilenames', $matchChildUrlPageFilenames);
+            }
+            $firstPath = strpos($path, '/') !== false ? substr($path, 0, strpos($path, '/')) : $path;
+            if (isset($matchChildUrlPageFilenames[$firstPath])) {
+                $ret = Kwf_Component_Data_Root::getInstance()->getComponentById($matchChildUrlPageFilenames[$firstPath]);
+                return $ret;
+            }
             $ret = $component->getChildPageByPath($path);
         }
 

--- a/Kwf/Component/Data/Root.php
+++ b/Kwf/Component/Data/Root.php
@@ -195,7 +195,11 @@ class Kwf_Component_Data_Root extends Kwf_Component_Data
             }
             $path = trim($path, '/');
             $ret = $this->getComponent()->getPageByUrl($path, $acceptLanguage);
-            if ($ret && rawurldecode($ret->url) == $parsedUrl['path']) { //nur cachen wenn kein redirect gemacht wird
+
+            if ($ret && (
+                   $ret->generator->getGeneratorFlag('matchChildUrls')
+                || rawurldecode($ret->url) == $parsedUrl['path']) //nur cachen wenn kein redirect gemacht wird
+            ) {
                 $exactMatch = true;
                 if ($ret->isVisible()) {
                     Kwf_Component_Cache_Url_Abstract::getInstance()->save($cacheUrl, $ret);


### PR DESCRIPTION
Can be used for javascript applications that use their own routing.
Only possible for static pages directly under root