### PR TITLE
Remove emailStyles from Kwc_Basic_Text_Component

### DIFF
--- a/Kwc/Basic/Text/Component.php
+++ b/Kwc/Basic/Text/Component.php
@@ -26,10 +26,7 @@ class Kwc_Basic_Text_Component extends Kwc_Abstract
             'enableStyles'      => true,
             'enableStylesEditor'=> true,
             'enableTagsWhitelist'=> true,
-            'defaultText'       => Kwc_Abstract::LOREM_IPSUM,
-
-            //veraltert NICHT VERWENDEN!! (in der Kwc_Mail komponente ist ein besserer ersatz)
-            'emailStyles'       => array()
+            'defaultText'       => Kwc_Abstract::LOREM_IPSUM
         ));
 
         $ret['stylesModel'] = 'Kwc_Basic_Text_StylesModel';
@@ -147,7 +144,6 @@ class Kwc_Basic_Text_Component extends Kwc_Abstract
                 $ret['contentParts'][] = $part;
             }
         }
-        $ret['styles'] = $this->_getSetting('emailStyles');
         return $ret;
     }
 

--- a/Kwc/Basic/Text/Mail.html.tpl
+++ b/Kwc/Basic/Text/Mail.html.tpl
@@ -1,5 +1,5 @@
 <?php
 foreach ($this->contentParts as $part) {
-    echo is_string($part) ? $this->mailFormat($part, $this->styles) : $this->component($part['component']);
+    echo is_string($part) ? $part : $this->component($part['component']);
 }
 ?>


### PR DESCRIPTION
This was a legacy feature that was replaced by a better solution a long time ago.
Use the 'getHtmlStyles()' feature of Kwc_Mail_Component instead.