### PR TITLE
Implement LoginRedirect not in View Plugin

### DIFF
--- a/Kwf/Component/Abstract/ContentSender/Default.php
+++ b/Kwf/Component/Abstract/ContentSender/Default.php
@@ -81,6 +81,14 @@ class Kwf_Component_Abstract_ContentSender_Default extends Kwf_Component_Abstrac
             if (!$ignore) Kwf_Setup::checkPreLogin($this->_data->getBaseProperty('preLoginUser'), $this->_data->getBaseProperty('preLoginPassword'));
         }
 
+        foreach ($this->_data->getPlugins('Kwf_Component_Plugin_Interface_Redirect') as $p) {
+            $p = Kwf_Component_Plugin_Abstract::getInstance($p, $this->_data->componentId);
+            if ($redirect = $p->getRedirectUrl($this->_data)) {
+                header('Location: '.$redirect);
+                exit;
+            }
+        }
+
         $benchmarkEnabled = Kwf_Benchmark::isEnabled();
 
         if ($benchmarkEnabled) $startTime = microtime(true);

--- a/Kwf/Component/Plugin/Interface/Redirect.php
+++ b/Kwf/Component/Plugin/Interface/Redirect.php
@@ -1,0 +1,5 @@
+<?php
+interface Kwf_Component_Plugin_Interface_Redirect
+{
+    public function getRedirectUrl(Kwf_Component_Data $page);
+}

--- a/Kwf/Component/Plugin/LoginRedirect/Component.php
+++ b/Kwf/Component/Plugin/LoginRedirect/Component.php
@@ -1,6 +1,7 @@
 <?php
 class Kwf_Component_Plugin_LoginRedirect_Component extends Kwf_Component_Plugin_Abstract
-    implements Kwf_Component_Plugin_Interface_ViewReplace, Kwf_Component_Plugin_Interface_Login, Kwf_Component_Plugin_Interface_SkipProcessInput
+    implements Kwf_Component_Plugin_Interface_ViewReplace, Kwf_Component_Plugin_Interface_Login,
+               Kwf_Component_Plugin_Interface_SkipProcessInput, Kwf_Component_Plugin_Interface_Redirect
 {
     public static function getSettings($param = null)
     {
@@ -9,14 +10,21 @@ class Kwf_Component_Plugin_LoginRedirect_Component extends Kwf_Component_Plugin_
         return $ret;
     }
 
-    public function replaceOutput($renderer)
+    public function getRedirectUrl(Kwf_Component_Data $page)
     {
         if (!$this->isLoggedIn()) {
             $url = $this->_getRedirectUrl();
             $connector = (strstr($url, '?')) ? '&' : '?';
-            $url .= $connector.'redirect=' . urlencode($this->_getRedirectParam());
-            header('Location: ' . $url);
-            exit;
+            $url .= $connector . 'redirect=' . urlencode($this->_getRedirectParam());
+            return $url;
+        }
+        return false;
+    }
+
+    public function replaceOutput($renderer)
+    {
+        if (!$this->isLoggedIn()) {
+            throw new Kwf_Exception("Component should not be rendered, redirect did not happen probably because this plugin is not used at page level");
         }
         return false;
     }


### PR DESCRIPTION
Using ViewReplace plugin for a redirect (using header('Location... and exit) never has been a good idea.
It is a practical problem now with ContentApi where we get the redirect for the api request.

This change adds a new Redirect Plugin Interface that allows a plugin returning a redirect url. This is done before
rendering and processInput (which will solve a few problems we had there with unauthenticated users)

Downside of this change: it only works when the plugin is at page level