### PR TITLE
Track internal searches in statistics

### DIFF
--- a/Kwc/FulltextSearch/Search/ViewAjax/Component.defer.js
+++ b/Kwc/FulltextSearch/Search/ViewAjax/Component.defer.js
@@ -1,0 +1,27 @@
+var onReady = require('kwf/on-ready');
+var $ = require('jQuery');
+var statistics = require('kwf/statistics');
+
+onReady.onRender('.kwcClass', function (el, config) {
+
+    var getSearchValue = function() {
+        var view = el[0].kwcViewAjax;
+        if (view && view.searchForm) {
+            var seachValues = view.searchForm.getValues();
+            if (seachValues.query) {
+                return seachValues.query;
+            }
+        }
+    };
+    el.find('.kwcBem__viewContainer').on('searchTermEntered', function() {
+        var searchValue = getSearchValue();
+        if (searchValue) {
+            statistics.trackView({internal_search_term: searchValue});
+        }
+    });
+    var searchValue = getSearchValue();
+    if (searchValue) {
+        statistics.addTrackingData({internal_search_term: searchValue});
+    }
+
+}, { priority: 1 });

--- a/commonjs/statistics.js
+++ b/commonjs/statistics.js
@@ -1,5 +1,6 @@
 var views = [];
 var events = [];
+var addTrackingData = [];
 
 var Statistics = {};
 Statistics.onView = function(fn) {
@@ -8,13 +9,16 @@ Statistics.onView = function(fn) {
 Statistics.onEvent = function(fn) {
     events.push(fn);
 };
+Statistics.onAddTrackingData = function(fn) {
+    addTrackingData.push(fn);
+};
 
 Statistics.count = Statistics.onView;
 Statistics.onCount = Statistics.onView;
 
-Statistics.trackView = function(url) {
+Statistics.trackView = function(data) {
     views.forEach(function(c) {
-        c.call(this, url);
+        c.call(this, data);
     }, this);
 };
 
@@ -23,5 +27,12 @@ Statistics.trackEvent = function(category, action, name, value) {
         c.call(this, category, action, name, value);
     }, this);
 };
-module.exports = Statistics;
 
+Statistics.addTrackingData = function(data) {
+    addTrackingData.forEach(function(c) {
+        c.call(this, data);
+    }, this);
+};
+
+
+module.exports = Statistics;

--- a/commonjs/view-ajax/view.js
+++ b/commonjs/view-ajax/view.js
@@ -117,6 +117,7 @@ ViewAjax.prototype = {
                     this.load();
                     clearTimeout(this.addHistoryEntryTimer);
                     this.addHistoryEntryTimer = setTimeout(this.pushSearchFormHistoryState.bind(this), 2000);
+                    this.$el.trigger('searchTermEntered', this._getState().searchFormValues);
                 }
             }, this, { buffer: 500 });
 


### PR DESCRIPTION
- Depends on event emitted in ajax-view after setting location (this is because
  only setting the location is the only debounced action in ajax-view)
- Adds new statistics-event for adding data to track before actually the
  statistics-tag is loaded
- Tracks search-term when search page is loaded and when search term is updated
  and live search is active