### PR TITLE
Add chunkhash parameter to chunkFilename for cache-busting

### DIFF
--- a/node_modules_build/kwf-webpack/config/webpack.kwf.config.js
+++ b/node_modules_build/kwf-webpack/config/webpack.kwf.config.js
@@ -60,7 +60,7 @@ module.exports = {
         path: process.cwd()+"/build/assets",
         publicPath: (kwfConfig['webpack-dev-server-url'] ? kwfConfig['webpack-dev-server-url'] : '/') + "assets/build/",
         filename: '[name].js',
-        chunkFilename: "[id].js",
+        chunkFilename: "[id].js?v=[chunkhash]",
         jsonpFunction: uniquePrefix+'webpackJsonp',
         pathinfo: devBuild //Include comments with information about the modules
     },


### PR DESCRIPTION
This adds version-parameter to defer.js file, other files are not
effected. Therefore we still need hash: true in webpack.kwc.config.js
Adding [chunkhash] as parameter to filename param (currently [name].js)
would work for Frontend.js but does not consider changes in de.Frontend.js
requiring some more changes (e.g. improvement of parameter added
in trl-html-webpack-plugin.js) in kwf build code.