### PR TITLE
Anonymize IP for Google Analytics

### DIFF
--- a/Kwc/Statistics/Analytics/Component.tpl
+++ b/Kwc/Statistics/Analytics/Component.tpl
@@ -4,6 +4,7 @@
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '<?=$this->code?>']);
   _gaq.push(['_trackPageview']);
+  _gaq.push(['_gat._anonymizeIp']);
 
   if (!location.search.match(/[\?&]kwcPreview/)) {
       (function() {


### PR DESCRIPTION
Prior to 3.4 anonymizeIp was set, the imprint text still says that it is set and management says that it should be set without the possibility to change the behaviour.

This is to be merged up to 5.1