### PR TITLE
Only select first switchLink and switchContainer

### DIFF
--- a/Kwf_js/EyeCandy/Switch/Display.js
+++ b/Kwf_js/EyeCandy/Switch/Display.js
@@ -15,8 +15,8 @@ var $ = require('jQuery');
         $.extend(this.config, config);
 
         this.el = $(el);
-        this.switchLink = this.el.find(this.config.link || '.kwfUp-switchLink:first');
-        this.switchContainer = this.el.find(this.config.container || '.kwfUp-switchContent:first');
+        this.switchLink = $(this.el.find(this.config.link || '.kwfUp-switchLink')[0]);
+        this.switchContainer = $(this.el.find(this.config.container || '.kwfUp-switchContent')[0]);
         this.boundEvent = this.config.hover ? 'hover' : 'click';
         this.activeTimeout = null;
 


### PR DESCRIPTION
This prevents opening/closing a switchDisplay component inside
or outside of the current switchDisplay component.