### PR TITLE
Add redirect-url to params

### DIFF
--- a/Kwf/Controller/Action/User/LoginController.php
+++ b/Kwf/Controller/Action/User/LoginController.php
@@ -168,8 +168,10 @@ class Kwf_Controller_Action_User_LoginController extends Kwf_Controller_Action
         if ($action == 'login') {
             if (count($state) != 4) throw new Kwf_Exception_NotFound();
             $redirect = urldecode(str_replace('kwfdot', '.', $state[3]));
+            $params = $this->getRequest()->getParams();
+            $params['redirect'] = urlencode($redirect);
             try {
-                $user = $authMethods[$authMethod]->getUserToLoginByCallbackParams($this->_getRedirectBackUrl(), $this->getRequest()->getParams());
+                $user = $authMethods[$authMethod]->getUserToLoginByCallbackParams($this->_getRedirectBackUrl(), $params);
             } catch (Kwf_Exception_Client $e) {
                 $this->getRequest()->setParam('redirect', urlencode($redirect));
                 $this->getRequest()->setParam('errorMessage', $e->getMessage());


### PR DESCRIPTION
This was done to let the login-page know the original url when a user tries
to login via facebook and get's redirected to the login-page again.
A popup will be shown there that requires the user to accept terms and conditions
and only on acceptance will a user be redirected to the actual page they came from.