### PR TITLE
Add daily maintenance-job to delete old enquiries

### DIFF
--- a/Kwc/Root/Abstract.php
+++ b/Kwc/Root/Abstract.php
@@ -92,6 +92,7 @@ class Kwc_Root_Abstract extends Kwc_Abstract implements Kwf_Util_Maintenance_Job
     public static function getMaintenanceJobs()
     {
         return array(
+            'Kwc_Root_MaintenanceJobs_DeleteOldEnquiries',
             'Kwc_Root_MaintenanceJobs_PageMetaUpdate',
             'Kwc_Root_MaintenanceJobs_PageMetaRebuild',
             'Kwc_Root_MaintenanceJobs_CacheCleanup'

--- a/Kwc/Root/MaintenanceJobs/DeleteOldEnquiries.php
+++ b/Kwc/Root/MaintenanceJobs/DeleteOldEnquiries.php
@@ -1,0 +1,21 @@
+<?php
+class Kwc_Root_MaintenanceJobs_DeleteOldEnquiries extends Kwf_Util_Maintenance_Job_Abstract
+{
+    public function getFrequency()
+    {
+        return self::FREQUENCY_DAILY;
+    }
+
+    public function execute($debug)
+    {
+        $model = Kwf_Model_Abstract::getInstance('Kwf_Model_Mail');
+        $deleteAfterDays = Kwf_Config::getValue('enquiries.deleteAfterDays');
+
+        if ($deleteAfterDays) {
+            $deleteBeforeDate = new Kwf_Date("-{$deleteAfterDays}days");
+            $select = new Kwf_Model_Select();
+            $select->where(new Kwf_Model_Select_Expr_Lower('save_date', $deleteBeforeDate));
+            $model->deleteRows($select);
+        }
+    }
+}

--- a/config.ini
+++ b/config.ini
@@ -92,6 +92,8 @@ assets.sourceAccess.html5shiv = html5shiv/dist/html5shiv.min.js
 assets.sourceAccess.es5shim = es5-shim/es5-shim.js
 assets.useCacheSimpleStatic = true
 
+enquiries.deleteAfterDays = 365
+
 mediaCacheDir = cache/media
 mediametaCacheDir = cache/mediameta
 mediaOutputCacheBackend =


### PR DESCRIPTION
By default all enquiries older than one year will be deleted.
If the enquiries should never be deleted, set the config setting
"enquiries.deleteAfterDays" to false.