### PR TITLE
OnReady check element.outerHTML for matching css-classes

### DIFF
--- a/commonjs/on-ready.js
+++ b/commonjs/on-ready.js
@@ -120,8 +120,8 @@ var callOnContentReady = function(renderedEl, options)
 
         if (options.action == 'render' && !html) {
             var t = benchmarkBox.now();
-            html = renderedEl.innerHTML;
-            benchmarkBox.time('innerHTML', benchmarkBox.now()-t);
+            html = renderedEl.outerHTML;
+            benchmarkBox.time('outerHTML', benchmarkBox.now()-t);
         }
 
         var useSelectorCache;
@@ -142,7 +142,7 @@ var callOnContentReady = function(renderedEl, options)
                 } else {
                     useSelectorCache = false;
                 }
-                benchmarkBox.time('checkInnerHtml', benchmarkBox.now()-t);
+                benchmarkBox.time('checkOuterHtml', benchmarkBox.now()-t);
             }
         }
 


### PR DESCRIPTION
this is required for integratorTemplate to work for ajax requests
as its component.js onReady does listen to a selector matching class
in body-tag.