### PR TITLE
symfony session save handler must be wrapped in SessionHandlerProxy

### DIFF
--- a/KwfBundle/HttpFoundation/Session/KwfSessionStorage.php
+++ b/KwfBundle/HttpFoundation/Session/KwfSessionStorage.php
@@ -1,8 +1,10 @@
 <?php
 namespace KwfBundle\HttpFoundation\Session;
 
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
 
 class KwfSessionStorage extends PhpBridgeSessionStorage
 {
@@ -16,7 +18,7 @@ class KwfSessionStorage extends PhpBridgeSessionStorage
     public function setSaveHandler($saveHandler = null)
     {
         //parent::setSaveHandler($saveHandler);
-        $this->saveHandler = $saveHandler;
+        $this->saveHandler = new SessionHandlerProxy($saveHandler);
     }
 
     public function start()


### PR DESCRIPTION
errors since 2.8.41 when logged in