### PR TITLE
gallery-component: add 'width: 100%' to col1

### DIFF
--- a/Kwc/List/Gallery/Component.scss
+++ b/Kwc/List/Gallery/Component.scss
@@ -62,6 +62,12 @@ div.kwcClass {
         }
     }
 
+    &.col1 {
+        > .listItem, > .morePics > .listItem {
+            width: 100%;
+        }
+    }
+
     @for $i from 3 through 10 {
         &.col#{$i} {
             @if $i % 2 == 0 {


### PR DESCRIPTION
so images don't disapear under 600px (mobile)