### PR TITLE
Use https-url for image if available

### DIFF
--- a/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.php
+++ b/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.php
@@ -26,12 +26,7 @@ class Kwc_Box_MetaTagsContent_OpenGraphImage_Component extends Kwc_Abstract_Imag
     {
         $ret = parent::getTemplateVars($renderer);
 
-        $imageUrl = $this->getAbsoluteImageUrl();
-        $ret['imageSecureUrl'] = '';
-        if (substr($imageUrl, 0, 8) == 'https://') {
-            $ret['imageSecureUrl'] = $imageUrl;
-        }
-        $ret['imageUrl'] = $imageUrl;
+        $ret['imageUrl'] = $this->getAbsoluteImageUrl();
         $ret['width'] = '';
         $ret['height'] = '';
         $imageDimensions = $this->getImageDimensions();

--- a/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.php
+++ b/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.php
@@ -25,15 +25,12 @@ class Kwc_Box_MetaTagsContent_OpenGraphImage_Component extends Kwc_Abstract_Imag
     public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer)
     {
         $ret = parent::getTemplateVars($renderer);
+
         $imageUrl = $this->getAbsoluteImageUrl();
-
-        //always use http, see http://stackoverflow.com/a/8858052/781662
-        if (substr($imageUrl, 0, 6) == 'https:') {
-            $imageUrl = 'http:'.substr($imageUrl, 6);
-        } else if (substr($imageUrl, 0, 2) == '//') {
-            $imageUrl = 'http:'.$imageUrl;
+        $ret['imageSecureUrl'] = '';
+        if (substr($imageUrl, 0, 8) == 'https://') {
+            $ret['imageSecureUrl'] = $imageUrl;
         }
-
         $ret['imageUrl'] = $imageUrl;
         $ret['width'] = '';
         $ret['height'] = '';

--- a/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.tpl
+++ b/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.tpl
@@ -1,6 +1,9 @@
 <?php if ($this->imageUrl) { ?>
 <meta property="og:image" content="<?=$this->imageUrl?>" />
 <?php } ?>
+<?php if ($this->imageSecureUrl) { ?>
+<meta property="og:image:secure_url" content="<?=$this->imageSecureUrl?>" />
+<?php } ?>
 <?php if ($this->width) { ?>
 <meta property="og:image:width" content="<?=$this->width?>" />
 <?php } ?>

--- a/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.tpl
+++ b/Kwc/Box/MetaTagsContent/OpenGraphImage/Component.tpl
@@ -1,9 +1,6 @@
 <?php if ($this->imageUrl) { ?>
 <meta property="og:image" content="<?=$this->imageUrl?>" />
 <?php } ?>
-<?php if ($this->imageSecureUrl) { ?>
-<meta property="og:image:secure_url" content="<?=$this->imageSecureUrl?>" />
-<?php } ?>
 <?php if ($this->width) { ?>
 <meta property="og:image:width" content="<?=$this->width?>" />
 <?php } ?>


### PR DESCRIPTION
To let facebook catch an previewimage from an https websitelink, the metatag og:image:secure_url has to be set.