### PR TITLE
Fix endless scrolling with Kwc_Form_NonAjax_Component

### DIFF
--- a/Kwc/Form/NonAjax/Component.defer.js
+++ b/Kwc/Form/NonAjax/Component.defer.js
@@ -1,0 +1,23 @@
+var $ = require('jquery');
+var onReady = require('kwf/commonjs/on-ready');
+var formRegistry = require('kwf/commonjs/frontend-form/form-registry');
+
+onReady.onRender('.kwcClass', function(form) {
+    var config = form.data('config');
+    if (!config) return;
+    this.config = config;
+
+    this.getValues = function() {
+        var ret = {};
+        $.each(form.find('form').serializeArray(), function(i, f) {
+            ret[f.name] = f.value;
+        });
+        return ret;
+    };
+
+    this.on = function() {
+        return false;
+    };
+
+    formRegistry.formsByComponentId[this.config.componentId] = this;
+}, { priority: -10, defer: true }); //initialize form very early, as many other components access it

--- a/Kwc/Form/NonAjax/Component.php
+++ b/Kwc/Form/NonAjax/Component.php
@@ -255,6 +255,10 @@ class Kwc_Form_NonAjax_Component extends Kwc_Abstract_Composite_Component
             $this->_formTrlStaticExecuted = true;
         }
 
+        $ret['config'] = array(
+            'componentId' => $this->getData()->componentId
+        );
+
         $ret['isPosted'] = $this->_posted;
         $ret['showSuccess'] = false;
         $ret['errors'] = Kwf_Form::formatValidationErrors($this->getErrors());

--- a/Kwc/Form/NonAjax/Component.twig
+++ b/Kwc/Form/NonAjax/Component.twig
@@ -1,4 +1,4 @@
-<div class="{{ rootElementClass }}{% if isPosted %} kwfUp-kwfImportant{% endif %}" data-width="100%">
+<div class="{{ rootElementClass }}{% if isPosted %} kwfUp-kwfImportant{% endif %}" data-width="100%" {% if config %}data-config="{{ config|json_encode }}"{% endif %}>
     {% if showSuccess %}
         {{ renderer.component(success) }}
     {% elseif message %}


### PR DESCRIPTION
On Render, the form needs to be added to the formRegistry.
getValues() and on() need to be defined in order for view-ajax/view.js
to be executed properly.