### PR TITLE
Add getItemIds for Trl-Directory

### DIFF
--- a/Kwc/Directories/List/Trl/Component.php
+++ b/Kwc/Directories/List/Trl/Component.php
@@ -48,6 +48,18 @@ class Kwc_Directories_List_Trl_Component extends Kwc_Abstract_Composite_Trl_Comp
         return $ret;
     }
 
+    public function getItemIds($select = null)
+    {
+        $ret = array();
+        $items = $this->getItems($select);
+        foreach ($items as $item) {
+            if ($item) {
+                $ret[] = $item->id;
+            }
+        }
+        return $ret;
+    }
+
     public function getSelect()
     {
         $itemDirectory = $this->getItemDirectory();


### PR DESCRIPTION
Can it be that we've never had a trl-directory with partial-id?
I can't really imagine that we didn't have this issue before.