### PR TITLE
Set encoding to allowed value

### DIFF
--- a/Kwf/Assets/Dispatcher.php
+++ b/Kwf/Assets/Dispatcher.php
@@ -22,7 +22,7 @@ class Kwf_Assets_Dispatcher
             $url = substr($url, 0, strpos($url, '?'));
         }
 
-        if ($encoding != 'none') {
+        if ($encoding != Kwf_Media_Output::ENCODING_NONE) {
             //own cache for encoded contents, not using Kwf_Assets_Cache as we don't need to in two-level cache
             $cacheId = 'as_'.str_replace(array(':', '/', ','), '_', $url).'_'.$encoding;
             $ret = Kwf_Cache_SimpleStatic::fetch($cacheId);

--- a/Kwf/Media/Output.php
+++ b/Kwf/Media/Output.php
@@ -175,7 +175,9 @@ class Kwf_Media_Output
                 }
             }
             $ret['encoding'] = $encoding;
-            $ret['headers'][] = 'Content-Encoding: ' . $encoding;
+            if ($encoding != self::ENCODING_NONE) {
+                $ret['headers'][] = 'Content-Encoding: ' . $encoding;
+            }
             $ret['headers'][] = 'Content-Type: ' . $file['mimeType'];
             if (!isset($file['contents']) && isset($file['contentsCallback'])) {
                 if (isset($file['cache'])) {


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding

"none" isn't a valid value and since a while facebook won't share the image sent with a wrong content-encoding value.