### PR TITLE
Fix problem with Child_First-Expression and not using tableNameAlias

### DIFF
--- a/Kwf/Model/Db.php
+++ b/Kwf/Model/Db.php
@@ -698,7 +698,7 @@ class Kwf_Model_Db extends Kwf_Model_Abstract
             }
             $col1 = $dbDepM->transformColumnName($ref['column']);
             $col2 = $dbDepOf->transformColumnName($dbDepOf->getPrimaryKey());
-            $depSelect->where("{$dbDepM->_formatField($col1)}={$dbDepOf->_formatField($col2)}");
+            $depSelect->where("{$dbDepM->_formatField($col1)}={$dbDepOf->_formatField($col2, null, $tableNameAlias)}");
             $depDbSelect = $dbDepM->_getDbSelect($depSelect);
             $exprStr = new Zend_Db_Expr($dbDepM->_formatField($expr->getField(), $depDbSelect));
             $depDbSelect->reset(Zend_Db_Select::COLUMNS);


### PR DESCRIPTION
This resultet in sql-exception "Unknown column 'xxxx.id' in 'where clause'"

This got lost with phabricator change. Commit-id in phabricator:
6f8f2def6173294dd21f808028f4bc8dab87e434
Author-Date: 15.12.2017 09:11; Branch 3.9.
Previous commit  in phabricator is existent. (827d05f7d2c0996e4aba6dbc9d7155cff5c5a460)