### PR TITLE
Add protected property $allowedEnvs to Kwf_SymfonyKernel

### DIFF
--- a/Kwf/SymfonyKernel.php
+++ b/Kwf/SymfonyKernel.php
@@ -7,15 +7,9 @@ abstract class Kwf_SymfonyKernel extends Kernel
 {
     public function __construct()
     {
-        $env = Kwf_Config::getValue('symfony.environment');
-        if (in_array($env, array('test', 'dev'))) {
-            $environment = $env;
-            $debug = true;
-            //Debug::enable();
-        } else {
-            $environment = 'prod';
-            $debug = false;
-        }
+        $environment = (Kwf_Config::getValue('symfony.environment')) ? Kwf_Config::getValue('symfony.environment') : 'prod';
+        $debug = (Kwf_Config::getValue('symfony.environment.debug')) ? Kwf_Config::getValue('symfony.environment.debug') : false;
+        
         parent::__construct($environment, $debug);
 
         AnnotationRegistry::registerLoader(array('Kwf_Loader', 'loadClass'));

--- a/config.ini
+++ b/config.ini
@@ -212,6 +212,8 @@ modelProviders.default = Kwf_Model_Provider_Default
 modelProviders.components = Kwf_Model_Provider_Components
 
 symfony.environment = prod
+symfony.environment.debug = false
+
 maintenanceJobs.pageMetaRebuildMaxTime =
 
 [test : production]
@@ -232,4 +234,5 @@ server.gearman.functionPrefix = test
 fulltext.solr.basePath = /test.%appid%
 clearCacheSkipProcessControl = true
 symfony.environment = test
+symfony.environment.debug = true
 maintenanceJobs.sendFailNotification = false


### PR DESCRIPTION
Before the allowed envs were limited to prod, dev and test. If you need more or different envs you have to overwrite the constructor. With $allowedEnvs you can customize your allowed envs in your Child Kernel without overwriting its parent constructor.