### PR TITLE
Add native support for Anchors in Trl-Component

### DIFF
--- a/Kwc/Chained/Trl/Component.php
+++ b/Kwc/Chained/Trl/Component.php
@@ -5,7 +5,7 @@ class Kwc_Chained_Trl_Component extends Kwc_Chained_Abstract_Component
     {
         $ret = parent::getSettings();
         $copySettings = array('componentName', 'componentIcon', 'editComponents', 'viewCache', 'contentSender', 'plugins', 'masterTemplate');
-        $copyFlags = array('processInput', 'menuCategory', 'chainedType', 'subroot', 'hasAlternativeComponent', 'resetMaster', 'noIndex');
+        $copyFlags = array('processInput', 'menuCategory', 'chainedType', 'subroot', 'hasAlternativeComponent', 'resetMaster', 'noIndex', 'hasAnchors');
         $ret = Kwc_Chained_Abstract_Component::getChainedSettings($ret, $masterComponentClass, 'Trl', $copySettings, $copyFlags);
         return $ret;
     }
@@ -13,5 +13,10 @@ class Kwc_Chained_Trl_Component extends Kwc_Chained_Abstract_Component
     public static function getChainedByMaster($masterData, $chainedData, $select = array())
     {
         return Kwc_Chained_Abstract_Component::_getChainedByMaster($masterData, $chainedData, 'Trl', $select);
+    }
+
+    public function getAnchors()
+    {
+        return $this->getData()->chained->getComponent()->getAnchors();
     }
 }


### PR DESCRIPTION
Otherwise every component wich defines anchors has to be translated even though the anchors themselves don't have to be translated.