### PR TITLE
Check for number value

### DIFF
--- a/Kwc/Abstract/Image/DimensionField.php
+++ b/Kwc/Abstract/Image/DimensionField.php
@@ -66,7 +66,7 @@ class Kwc_Abstract_Image_DimensionField extends Kwf_Form_Field_Abstract
         }
         if (!is_array($value)) $value = array();
         $row->dimension = isset($value['dimension']) ? $value['dimension'] : null;
-        $row->width = (isset($value['width']) && $value['width']) ? $value['width'] : null;
+        $row->width = (isset($value['width']) && (int)$value['width']) ? $value['width'] : null;
         $row->height = (isset($value['height']) && $value['height']) ? $value['height'] : null;
         if (isset($value['cropData'])) {
             $row->crop_x = (isset($value['cropData']['x']) && $value['cropData']['x'] !== null)


### PR DESCRIPTION
width can be the value contentWidth when an FullWidthImage is used as
a subcomponent in a custom grid-form because setCreateMissingRow is not
used and so the contentWidth is not set via Kwc_Abstract_Image_ImageFile
(which then replaces the contentWidth value in the js-files).