### PR TITLE
added validator for parsing all errors from paramFetcher

### DIFF
--- a/KwfBundle/EventListener/ExceptionHandler.php
+++ b/KwfBundle/EventListener/ExceptionHandler.php
@@ -1,10 +1,13 @@
 <?php
 namespace KwfBundle\EventListener;
 
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
+use KwfBundle\Validator\ValidationException;
 
 class ExceptionHandler
 {
@@ -19,10 +22,23 @@ class ExceptionHandler
     {
         if ($event->isPropagationStopped()) return;
 
+        $acceptsJson = in_array('application/json', $event->getRequest()->getAcceptableContentTypes());
         $exception = $event->getException();
-        if ($exception instanceof HttpExceptionInterface) {
+        if ($exception instanceof ValidationException) {
+            if ($acceptsJson) {
+                $event->setResponse(new JsonResponse(array(
+                    'error' => array(
+                        'code' => $exception->getStatusCode(),
+                        'message' => $exception->getMessage(),
+                        'errors' => $exception->getErrors()
+                    )
+                ), $exception->getStatusCode()));
+            } else {
+                $event->setResponse(new Response($exception->getMessage(), $exception->getStatusCode()));
+            }
+        } else if ($exception instanceof HttpExceptionInterface) {
             $request = $event->getRequest();
-            if (in_array('application/json', $request->getAcceptableContentTypes())) {
+            if ($acceptsJson) {
                 $request->setRequestFormat('json');
             }
 

--- a/KwfBundle/Resources/config/services.yml
+++ b/KwfBundle/Resources/config/services.yml
@@ -80,3 +80,6 @@ services:
 
     kwf.updates_provider_locator:
         class: KwfBundle\UpdatesProvider\Locator
+
+    kwf.validator.error_collect_validator:
+        class: KwfBundle\Validator\ErrorCollectValidator

--- a/KwfBundle/Validator/ErrorCollectValidator.php
+++ b/KwfBundle/Validator/ErrorCollectValidator.php
@@ -1,0 +1,60 @@
+<?php
+namespace KwfBundle\Validator;
+
+use FOS\RestBundle\Exception\InvalidParameterException;
+use FOS\RestBundle\Request\ParamFetcher;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class ErrorCollectValidator
+{
+    /**
+     * @param ParamFetcher $paramFetcher
+     * @return array
+     */
+    public function validate(ParamFetcher $paramFetcher)
+    {
+        $errors = array();
+
+        foreach ($paramFetcher->getParams() as $param) {
+            try {
+                $paramFetcher->get($param->getName());
+            } catch (InvalidParameterException $exception) {
+                $errors[$param->getName()] = $this->parseViolations($exception->getViolations());
+            } catch (BadRequestHttpException $exception) {
+                $errors[$param->getName()] = array($exception->getMessage());
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param ParamFetcher $paramFetcher
+     * @throws ValidationException
+     */
+    public function validateAndThrow(ParamFetcher $paramFetcher)
+    {
+        $errors = $this->validate($paramFetcher);
+        if (count($errors) > 0) {
+            $exception = new ValidationException();
+            $exception->setErrors($errors);
+            throw $exception;
+        }
+    }
+
+    /**
+     * @param ConstraintViolationListInterface $violationList
+     * @return array
+     */
+    private function parseViolations(ConstraintViolationListInterface $violationList)
+    {
+        $messages = array();
+
+        foreach ($violationList as $violation) {
+            $messages[] = $violation->getMessage();
+        }
+
+        return $messages;
+    }
+}

--- a/KwfBundle/Validator/ValidationException.php
+++ b/KwfBundle/Validator/ValidationException.php
@@ -1,0 +1,39 @@
+<?php
+namespace KwfBundle\Validator;
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use \Exception;
+
+class ValidationException extends BadRequestHttpException
+{
+    protected $errors;
+
+    /**
+     * ValidationException constructor.
+     * @param null $message
+     * @param Exception|null $previous
+     * @param int $code
+     */
+    public function __construct($message = null, Exception $previous = null, $code = 0)
+    {
+        if (!$message) $message = trlKwf('An error has occurred');
+
+        parent::__construct($message, $previous, $code);
+    }
+
+    /**
+     * @param array $errors
+     */
+    public function setErrors(array $errors)
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}


### PR DESCRIPTION
extended also exceptionHandler to normalize these errors

Usage:
```
$errors = $this->validator->validate($paramFetcher);
if (count($errors) > 0) {
    $exception = new ValidationException();
    $exception->setErrors($errors);
    throw $exception;
}
```
OR
```
$this->validator->validateAndThrow($paramFetcher);
```