### PR TITLE
Delete cache only when chained component is changed

### DIFF
--- a/Kwc/Basic/DownloadTag/Trl/Events.php
+++ b/Kwc/Basic/DownloadTag/Trl/Events.php
@@ -14,6 +14,7 @@ class Kwc_Basic_DownloadTag_Trl_Events extends Kwc_Basic_LinkTag_Abstract_Trl_Ev
 
     public function onMasterMediaCacheChanged(Kwf_Events_Event_Media_Changed $e)
     {
+        if ($e->component->parent->componentClass == $this->_class) return;
         foreach (Kwc_Chained_Trl_Component::getAllChainedByMaster($e->component, 'Trl') as $chained) {
             if (!$chained->getComponent()->getRow()->own_download) {
                 $this->fireEvent(new Kwf_Events_Event_Media_Changed(


### PR DESCRIPTION
Own child component has same class so it can happen that in goes into
this codepath