### PR TITLE
Fix duplicating statically generated Text Component when target alrea…

### DIFF
--- a/Kwc/Basic/Text/Admin.php
+++ b/Kwc/Basic/Text/Admin.php
@@ -53,6 +53,9 @@ class Kwc_Basic_Text_Admin extends Kwc_Admin
             }
         }
 
+
+        $targetRow = $source->getComponent()->getOwnModel()->getRow($target->dbId);
+        if ($targetRow) { $targetRow->delete(); }
         $source->getComponent()->getRow()->duplicate(array(
             'component_id' => $target->dbId,
             'content'      => $content

--- a/Kwc/Basic/Text/Row.php
+++ b/Kwc/Basic/Text/Row.php
@@ -141,18 +141,6 @@ class Kwc_Basic_Text_Row extends Kwf_Model_Proxy_Row
         return $rows->current()->nr;
     }
 
-    protected function _beforeDelete()
-    {
-        $table = new Kwc_Basic_Text_ChildComponentsModel();
-        $rows = $table->fetchAll(array('component_id = ?' => $this->component_id));
-        foreach ($rows as $row) {
-            $t = substr($row->component, 0, 1);
-            $admin = Kwc_Admin::getInstance($this->_classes[$row->component]);
-            $admin->delete($this->component_id . '-' . $t.$row->nr);
-            $row->delete();
-        }
-    }
-
     //childComponents löschen die aus dem html-code entfernt wurden
     protected function _beforeSave()
     {


### PR DESCRIPTION
…dy exists in database

Fixes issue with component-deep-copy when Text is generated statically and for some reason the row already exists. Other components (Kwc_Abstract_Admin::_duplicateOwnRow) do the same.

Also remove completely broken _beforeDelete for Text Row. The implementation tried to delete child components using Kwc_Admin::delete which never really existed. But the
first problem was already in instanciating the ChildComponentsModel (as that requires a constructor parameter) - so this was never called and can be safely removed.