### PR TITLE
Fix wrong relation.

### DIFF
--- a/Kwc/NewsCategory/Model.php
+++ b/Kwc/NewsCategory/Model.php
@@ -2,6 +2,6 @@
 class Kwc_NewsCategory_Model extends Kwc_News_Directory_Model
 {
     protected $_dependentModels = array(
-        'Categories' => 'Kwc_News_Category_Directory_NewsToCategoriesModel'
+        'Categories' => 'Kwc_NewsCategory_Category_Directory_NewsToCategoriesModel'
     );
 }


### PR DESCRIPTION
It's already used in Kwc_NewsCategory_Category_Directory_NewsToCategoriesModel
but was not in Kwc_NewsCategory_Model. For this reason it was not possible
to listen to changes (event.php-listener) in Kwc_NewsCategory_Category_Directory_NewsToCategoriesModel.