### PR TITLE
Append query-string only when view cache is disabled

### DIFF
--- a/Kwc/Form/Component.php
+++ b/Kwc/Form/Component.php
@@ -311,7 +311,7 @@ class Kwc_Form_Component extends Kwc_Abstract_Composite_Component
             } else {
                 $ret['action'] = $this->getData()->url;
             }
-            if (isset($_SERVER["QUERY_STRING"])) {
+            if (!$this->_getSetting('viewCache') && isset($_SERVER["QUERY_STRING"])) {
                 $ret['action'] .= '?' . $_SERVER["QUERY_STRING"];
             }
 


### PR DESCRIPTION
Otherwise the query parameter would remain in the view cache