### PR TITLE
add 'array $info' with default value to 'load'-functions

### DIFF
--- a/Kwc/Directories/Item/Directory/Trl/FormController.php
+++ b/Kwc/Directories/Item/Directory/Trl/FormController.php
@@ -1,7 +1,7 @@
 <?php
 class Kwc_Directories_Item_Directory_Trl_FormController_ComponentData extends Kwf_Data_Table
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $name = $this->getField();
         $c = Kwf_Component_Data_Root::getInstance()->getComponentByDbId($row->component_id, array('ignoreVisible' => true));

--- a/Kwc/Form/Dynamic/Trl/Form.php
+++ b/Kwc/Form/Dynamic/Trl/Form.php
@@ -32,7 +32,7 @@ class Kwc_Form_Dynamic_Trl_Form extends Kwc_Abstract_Form
 
 class Kwc_Form_Dynamic_Trl_Data extends Kwf_Data_Abstract
 {
-    public function load($row)
+    public function load($row, array $info = array())
     {
         $c = Kwf_Component_Data_Root::getInstance()->getComponentByDbId($row->component_id, array('ignoreVisible'=>true));
         if ($c) {


### PR DESCRIPTION
prevents parent compatibility exceptions