### PR TITLE
TextImage: JS code to add gt420 class got accidently removed in 2015

### DIFF
--- a/Kwc/TextImage/Component.js
+++ b/Kwc/TextImage/Component.js
@@ -1,6 +1,8 @@
 var responsiveEl = require('kwf/commonjs/responsive-el');
 var onReady = require('kwf/commonjs/on-ready');
 
+responsiveEl('.kwcClass', [420]);
+
 //remove largeText class if >55% of element is covered by image
 onReady.onResize('.kwcClass', function textImage(el) {
     var img = el.find('.kwcBem__image .kwfUp-kwcImageContainer');


### PR DESCRIPTION
this breaks TextImage with image-dimension = original and order right
or left as width=50% is not applied.
Commit introducing this bug: 8afee1c5ad411e8fe49057cbca26dee4ddc05a17