### PR TITLE
Remove vendor-prefixes and compass-mixins

### DIFF
--- a/Kwc/Advanced/GoogleMapView/Component.scss
+++ b/Kwc/Advanced/GoogleMapView/Component.scss
@@ -1,6 +1,3 @@
-@import "config/colors";
-@import "compass/css3/transition";
-
 .kwcClass {
     .mobileOverlayOpen, .mobileOverlayClose {
         display: none;
@@ -13,8 +10,8 @@
     &.optimizedMobileUI {
         margin-bottom: 20px;
         position: relative;
-        @include transition-property(all);
-        @include transition-duration(.24s);
+        transition-property: all;
+        transition-duration: .24s;
 
         .mobileOverlayOpen {
             background: url('/assets/kwf/Kwc/Advanced/GoogleMapView/navigateIcon.png') no-repeat center 106px rgba(0, 0, 0, 0.7);
@@ -27,8 +24,8 @@
             right: 0;
             left: 0;
             top: 0;
-            @include transition-property(all);
-            @include transition-duration(.24s);
+            transition-property: all;
+            transition-duration: .24s;
         }
 
         .navigateIcon {

--- a/Kwc/Advanced/YoutubeWithPreviewImage/Component.scss
+++ b/Kwc/Advanced/YoutubeWithPreviewImage/Component.scss
@@ -6,7 +6,6 @@
         cursor: pointer;
         z-index: 2;
         opacity: 1;
-        -webkit-transition: opacity 0.5s;
         transition: opacity 0.5s;
     }
 
@@ -22,7 +21,6 @@
         width: auto;
         z-index: 3;
         opacity: 0;
-        -webkit-transition: opacity 0.5s;
         transition: opacity 0.5s;
     }
 

--- a/Kwc/Basic/BackgroundWindowWidth/Component.scss
+++ b/Kwc/Basic/BackgroundWindowWidth/Component.scss
@@ -1,6 +1,4 @@
 @import "config/colors";
-@import "compass/css3/opacity";
-@import "compass/css3/box-sizing";
 
 .kwcClass {
     .kwcBem__background {
@@ -11,7 +9,7 @@
         z-index: 2;
 
         &.kwcBem__background--opaque {
-            @include opacity(0.7);
+            opacity: 0.7;
         }
 
         &.kwcBem__backgroundImage {
@@ -59,6 +57,6 @@
         z-index: 3;
         position: relative;
         padding: 30px 0;
-        @include box-sizing(border-box);
+        box-sizing: border-box;
     }
 }

--- a/Kwc/Basic/ImageEnlarge/Component.scss
+++ b/Kwc/Basic/ImageEnlarge/Component.scss
@@ -1,5 +1,3 @@
-@import "compass/css3/transition";
-
 .kwcClass {
     position: relative;
 
@@ -31,7 +29,7 @@
             left: 0;
             top: 0;
             opacity: 0;
-            @include transition(opacity 0.25s ease-in-out);
+            transition: opacity 0.25s ease-in-out;
 
             .innerHoverIcon {
                 display: block;

--- a/Kwc/Columns/Component.scss
+++ b/Kwc/Columns/Component.scss
@@ -1,5 +1,3 @@
-@import "compass/css3/box-sizing";
-
 .kwcClass {
     > .listItem {
         padding-bottom: 20px;
@@ -21,7 +19,7 @@
     margin-right: -20px;
 
     > .listItem {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         padding-right: 20px;
         float: left;
         display: inline;

--- a/Kwc/Directories/List/ViewMap/Component.scss
+++ b/Kwc/Directories/List/ViewMap/Component.scss
@@ -1,5 +1,3 @@
-@import "compass/css3/transition";
-
 .kwcClass {
     .mobileOverlayOpen, .mobileOverlayClose {
         display: none;
@@ -8,8 +6,8 @@
     &.optimizedMobileUI {
         margin-bottom: 20px;
         position: relative;
-        @include transition-property(all);
-        @include transition-duration(.24s);
+        transition-property: all;
+        transition-duration: .24s;
 
         .mobileOverlayOpen {
             background: url('/assets/kwf/Kwc/Advanced/GoogleMapView/navigateIcon.png') no-repeat center 106px rgba(0, 0, 0, 0.7);
@@ -22,8 +20,8 @@
             right: 0;
             left: 0;
             top: 0;
-            @include transition-property(all);
-            @include transition-duration(.24s);
+            transition-property: all;
+            transition-duration: .24s;
         }
 
         .navigateIcon {

--- a/Kwc/List/Gallery/Component.scss
+++ b/Kwc/List/Gallery/Component.scss
@@ -1,6 +1,4 @@
-@import "compass/css3/box-sizing";
 @import "compass/utilities/general/clearfix";
-@import "compass/css3/transition";
 
 $contentMargin  : 10px;
 $breakpoint     : 600;
@@ -16,9 +14,9 @@ div.kwcClass {
 
     .listItem {
         opacity: 1;
-        @include transition-property(opacity);
-        @include transition-duration(0.25s);
-        @include transition-timing-function(cubic-bezier(0.215, 0.61, 0.355, 1));
+        transition-property: opacity;
+        transition-duration: 0.25s;
+        transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
 
     &.hidePics {
@@ -26,12 +24,12 @@ div.kwcClass {
             padding: 0px !important;
             width: 0px !important;
             opacity: 0;
-            @include transition-duration(0s);
+            transition-duration: 0s;
         }
     }
 
     > .listItem, > .morePics > .listItem {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         padding: 0 $contentMargin 7px 0;
         position: relative;
         margin: 0;

--- a/Kwc/Menu/DropdownMask/Component.scss
+++ b/Kwc/Menu/DropdownMask/Component.scss
@@ -1,7 +1,3 @@
-@import "compass/css3/box-sizing";
-@import "compass/css3/transition";
-@import "compass/css3/opacity";
-
 .kwfUp-kwcMenuDropdownMaskMask {
     height: 100%;
     width: 100%;
@@ -11,7 +7,7 @@
     z-index: 11;
     background: #000000;
     visibility: hidden;
-    @include opacity(0.7);
+    opacity: 0.7;
 
     &.visible {
         visibility: visible;
@@ -39,7 +35,7 @@
                     min-width: 150px;
 
                     li {
-                        @include box-sizing(border-box);
+                        box-sizing: border-box;
                         float: left;
                         width: 100%;
                         display: block;

--- a/Kwc/Menu/Mobile/Component.scss
+++ b/Kwc/Menu/Mobile/Component.scss
@@ -1,7 +1,5 @@
 @import "config/colors";
-@import "compass/css3/box-sizing";
 @import "kwf/background-image-dpr2";
-@import "compass/css3/transition";
 
 .kwcClass {
     overflow: hidden;
@@ -26,14 +24,14 @@
             width: 52px;
             z-index: 1;
             top: 0px;
-            @include transition-delay(0.4s);
-            @include transition-property(all);
-            @include transition-duration(0s);
+            transition-delay: 0.4s;
+            transition-property: all;
+            transition-duration: 0s;
             &.active {
                 background-position: left center;
-                @include transition-delay(0s);
-                @include transition-property(all);
-                @include transition-duration(0s);
+                transition-delay: 0s;
+                transition-property: all;
+                transition-duration: 0s;
             }
         }
         > .kwfUp-slider {
@@ -64,7 +62,7 @@
                 width: 100%;
 
                 li {
-                    @include box-sizing(border-box);
+                    box-sizing: border-box;
                     padding: 0 15px 0 15px;
                     position: relative;
                     display: block;
@@ -127,15 +125,15 @@
         width: 52px;
         z-index: 1;
         top: 0px;
-        @include transition-delay(0.4s);
-        @include transition-property(all);
-        @include transition-duration(0s);
+        transition-delay: 0.4s;
+        transition-property: all;
+        transition-duration: 0s;
 
         &.kwfUp-active {
             background-position: left center;
-            @include transition-delay(0s);
-            @include transition-property(all);
-            @include transition-duration(0s);
+            transition-delay: 0s;
+            transition-property: all;
+            transition-duration: 0s;
         }
     }
 }

--- a/Kwc/News/List/AjaxView/Component.scss
+++ b/Kwc/News/List/AjaxView/Component.scss
@@ -1,4 +1,3 @@
-@import "compass/css3/box-sizing";
 @import "compass/utilities/general/clearfix";
 
 .kwcClass {
@@ -9,8 +8,8 @@
         }
 
         &__teaser {
-            @include box-sizing(border-box);
             @include pie-clearfix;
+            box-sizing: border-box;
             padding: 6px 10px;
         }
 

--- a/Kwc/News/List/View/Component.scss
+++ b/Kwc/News/List/View/Component.scss
@@ -1,4 +1,3 @@
-@import "compass/css3/box-sizing";
 @import "compass/utilities/general/clearfix";
 
 .kwcClass {
@@ -9,8 +8,8 @@
         }
 
         &__teaser {
-            @include box-sizing(border-box);
             @include pie-clearfix;
+            box-sizing: border-box;
             padding: 6px 10px;
         }
 

--- a/Kwc/Newsletter/Detail/StartNewsletterPanel.scss
+++ b/Kwc/Newsletter/Detail/StartNewsletterPanel.scss
@@ -1,8 +1,4 @@
 @import "compass/utilities/general/clearfix";
-@import "compass/css3/images";
-@import "compass/css3/opacity";
-@import "kwf/css3/border-radius";
-@import "kwf/css3/box-shadow";
 
 .kwcNewsletterButtons {
     @include pie-clearfix;
@@ -13,7 +9,7 @@
         float: left;
 
         button {
-            @include border-radius-pie(3px);
+            border-radius: 3px;
             width: 90%;
             margin: 0px auto 0px auto;
             display: block;
@@ -29,7 +25,7 @@
 
             .kwcNewsletterButtonStart {
                 background-color: #7fbf4d;
-                @include background-image(linear-gradient(#7fbf4d, #63a62f));
+                background-image: linear-gradient(#7fbf4d, #63a62f);
                 text-shadow: 0 -1px 0 #4C9021;
                 border: 1px solid #63A62F;
                 border-bottom: 1px solid #5B992B;
@@ -37,17 +33,17 @@
 
                 &:hover {
                     background-color: #76b347;
-                    @include background-image(linear-gradient(#76b347, #5e9e2e));
+                    background-image: linear-gradient(#76b347, #5e9e2e);
                 }
 
                 &:active {
                     border: 1px solid #5B992B;
                     border-bottom: 1px solid #538C27;
-                    @include box-shadow-pie(#548c29 0px 0px 8px 4px inset);
+                    box-shadow: inset 0 0 8px 4px #548c29;
                 }
 
                 &[disabled=disabled], &[disabled] {
-                    @include opacity(0.6);
+                    opacity: 0.6;
                     cursor: default;
                 }
             }
@@ -58,7 +54,7 @@
 
             .kwcNewsletterButtonPause {
                 background-color: #eee;
-                @include background-image(linear-gradient(#eee, #ccc));
+                background-image: linear-gradient(#eee, #ccc);
                 text-shadow: 0 1px 0 #eee;
                 border: 1px solid #ccc;
                 border-bottom: 1px solid #bbb;
@@ -66,7 +62,7 @@
 
                 &:hover {
                     background-color: #ddd;
-                    @include background-image(linear-gradient(#ddd, #bbb));
+                    background-image: linear-gradient(#ddd, #bbb);
                     border: 1px solid #bbb;
                     border-bottom: 1px solid #999;
                 }
@@ -74,7 +70,7 @@
                 &:active {
                     border: 1px solid #aaa;
                     border-bottom: 1px solid #888;
-                    @include box-shadow-pie(#aaa 0px 0px 8px 4px inset);
+                    box-shadow: inset 0 0 8px 4px #aaa;
                 }
             }
         }

--- a/Kwf_js/EyeCandy/Lightbox/Lightbox.scss
+++ b/Kwf_js/EyeCandy/Lightbox/Lightbox.scss
@@ -1,9 +1,6 @@
 @import "config/default-loading-animation-big";
 @import "config/lightbox-animation";
 @import "kwf/background-image-dpr2";
-@import "compass/css3/box-sizing";
-@import "compass/css3/transition";
-@import "compass/css3/transform";
 
 html.kwfUp-kwfLightboxActive, html.kwfUp-kwfLightboxActive body {
     overflow: hidden;
@@ -23,9 +20,8 @@ body {
         height: 100%;
 
         .kwfUp-kwfLightboxScroll {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             -webkit-overflow-scrolling: touch;
-            position: absolute;
             overflow-y: auto;
             position: fixed;
             padding: 10px;
@@ -51,7 +47,7 @@ body {
         }
 
         .kwfUp-kwfLightboxInner {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             display: inline-block;
             position: relative;
             text-align: left;
@@ -89,15 +85,15 @@ body {
 @if $animation-style == fadeIn {
     .kwfUp-kwfLightbox {
         .kwfUp-kwfLightboxInner {
-            @include transition-property(opacity);
-            @include transition-duration(150ms);
-            @include transition-timing-function(linear);
+            transition-property: opacity;
+            transition-duration: 150ms;
+            transition-timing-function: linear;
             opacity: 0;
         }
 
         &.kwfUp-kwfLightboxOpen {
             .kwfUp-kwfLightboxInner {
-                @include transition-duration(150ms);
+                transition-duration: 150ms;
                 opacity: 1;
             }
         }
@@ -105,13 +101,13 @@ body {
 
     body div.kwfUp-kwfLightboxCenterBox {
         .kwfUp-kwfLightboxMask {
-            @include transition-property(opacity);
-            @include transition-duration(150ms);
-            @include transition-timing-function(linear);
+            transition-property: opacity;
+            transition-duration: 150ms;
+            transition-timing-function: linear;
             opacity: 0;
 
             &.kwfUp-kwfLightboxMaskOpen {
-                @include transition-duration(150ms);
+                transition-duration: 150ms;
                 opacity: 0.8;
             }
         }
@@ -119,17 +115,17 @@ body {
 } @else if $animation-style == fadeInSlideUp {
     .kwfUp-kwfLightbox {
         .kwfUp-kwfLightboxInner {
-            @include transform(translateX(0) translateY(100px) scale(1));
-            @include transition(opacity 50ms linear, transform 0ms linear);
-            @include transition-delay(0ms);
+            transform: translateX(0) translateY(100px) scale(1);
+            transition: opacity 50ms linear, transform 0ms linear;
+            transition-delay: 0ms;
             opacity: 0;
         }
 
         &.kwfUp-kwfLightboxOpen {
             .kwfUp-kwfLightboxInner {
-                @include transform(translateX(0) translateY(0) scale(1));
-                @include transition(opacity 500ms cubic-bezier(0.215, 0.61, 0.355, 1), transform 400ms cubic-bezier(0.215, 0.61, 0.355, 1));
-                @include transition-delay(300ms);
+                transform: translateX(0) translateY(0) scale(1);
+                transition: opacity 500ms cubic-bezier(0.215, 0.61, 0.355, 1), transform 400ms cubic-bezier(0.215, 0.61, 0.355, 1);
+                transition-delay: 300ms;
                 opacity: 1;
             }
         }
@@ -137,11 +133,11 @@ body {
 
     body div.kwfUp-kwfLightboxCenterBox {
         .kwfUp-kwfLightboxMask {
-            @include transition(opacity 50ms linear);
+            transition: opacity 50ms linear;
             opacity: 0;
 
             &.kwfUp-kwfLightboxMaskOpen {
-                @include transition(opacity 1250ms cubic-bezier(0.23, 1, 0.32, 1));
+                transition: opacity 1250ms cubic-bezier(0.23, 1, 0.32, 1);
                 opacity: 0.8;
             }
         }
@@ -149,17 +145,17 @@ body {
 } @else if $animation-style == fadeInSlideInRight {
     .kwfUp-kwfLightbox {
         .kwfUp-kwfLightboxInner {
-            @include transform(translateX(100%) translateY(0) scale(1));
-            @include transition(opacity 0ms linear, transform 500ms cubic-bezier(0.215, 0.61, 0.355, 1));
-            @include transition-delay(0ms);
+            transform: translateX(100%) translateY(0) scale(1);
+            transition: opacity 0ms linear, transform 500ms cubic-bezier(0.215, 0.61, 0.355, 1);
+            transition-delay: 0ms;
             opacity: 0;
         }
 
         &.kwfUp-kwfLightboxOpen {
             .kwfUp-kwfLightboxInner {
-                @include transform(translateX(0) translateY(0) scale(1));
-                @include transition(opacity 300ms cubic-bezier(0.215, 0.61, 0.355, 1), transform 500ms cubic-bezier(0.215, 0.61, 0.355, 1));
-                @include transition-delay(150ms);
+                transform: translateX(0) translateY(0) scale(1);
+                transition: opacity 300ms cubic-bezier(0.215, 0.61, 0.355, 1), transform 500ms cubic-bezier(0.215, 0.61, 0.355, 1);
+                transition-delay: 150ms;
                 opacity: 1;
             }
         }
@@ -167,15 +163,15 @@ body {
 
     body div.kwfUp-kwfLightboxCenterBox {
         .kwfUp-kwfLightboxMask {
-            @include transition-property(opacity);
-            @include transition-duration(50ms);
-            @include transition-timing-function(linear);
+            transition-property: opacity;
+            transition-duration: 50ms;
+            transition-timing-function: linear;
             opacity: 0;
 
             &.kwfUp-kwfLightboxMaskOpen {
-                @include transition-property(opacity);
-                @include transition-duration(150ms);
-                @include transition-timing-function(linear);
+                transition-property: opacity;
+                transition-duration: 150ms;
+                transition-timing-function: linear;
                 opacity: 0.8;
             }
         }
@@ -183,17 +179,17 @@ body {
 } @else if $animation-style == fadeInZoom {
     .kwfUp-kwfLightbox {
         .kwfUp-kwfLightboxInner {
-            @include transform(translateX(0) translateY(0) scale(0.9));
-            @include transition(opacity 0ms linear, transform 0ms linear);
-            @include transition-delay(0ms);
+            transform: translateX(0) translateY(0) scale(0.9);
+            transition: opacity 0ms linear, transform 0ms linear;
+            transition-delay: 0ms;
             opacity: 0;
         }
 
         &.kwfUp-kwfLightboxOpen {
             .kwfUp-kwfLightboxInner {
-                @include transform(translateX(0) translateY(0) scale(1));
-                @include transition(opacity 500ms cubic-bezier(0.215, 0.61, 0.355, 1), transform 550ms cubic-bezier(0.215, 0.61, 0.355, 1));
-                @include transition-delay(150ms);
+                transform: translateX(0) translateY(0) scale(1);
+                transition: opacity 500ms cubic-bezier(0.215, 0.61, 0.355, 1), transform 550ms cubic-bezier(0.215, 0.61, 0.355, 1);
+                transition-delay: 150ms;
                 opacity: 1;
             }
         }
@@ -201,11 +197,11 @@ body {
 
     body div.kwfUp-kwfLightboxCenterBox {
         .kwfUp-kwfLightboxMask {
-            @include transition(opacity 50ms linear);
+            transition: opacity 50ms linear;
             opacity: 0;
 
             &.kwfUp-kwfLightboxMaskOpen {
-                @include transition(opacity 300ms linear);
+                transition: opacity 300ms linear;
                 opacity: 0.8;
             }
         }

--- a/Kwf_js/Utils/StickyHeader.scss
+++ b/Kwf_js/Utils/StickyHeader.scss
@@ -1,11 +1,4 @@
-@import "compass/css3/transition";
-@import "compass/css3/box-shadow";
-
 .kwfUtilsStickyHeader {
-   @include transition-property(all);
-   @include transition-duration(0.6s);
-
-   &.stick {
-        @include single-box-shadow;
-    }
+    transition-property: all;
+    transition-duration: 0.6s;
 }

--- a/css/loading.scss
+++ b/css/loading.scss
@@ -1,13 +1,3 @@
-@-moz-keyframes kwfLoadingSpin {
-    0% { -moz-transform:rotate(0deg); }
-    100% { -moz-transform:rotate(360deg); }
-}
-
-@-webkit-keyframes kwfLoadingSpin {
-    0% { -webkit-transform:rotate(0deg); }
-    100% { -webkit-transform:rotate(360deg); }
-}
-
 @keyframes kwfLoadingSpin {
     0% { transform:rotate(0deg); }
     100% { transform:rotate(360deg); }

--- a/sass/Kwf/stylesheets/_kwf.scss
+++ b/sass/Kwf/stylesheets/_kwf.scss
@@ -1,2 +1,1 @@
-@import "kwf/css3";
 @import "kwf/mobile-breakpoint";

--- a/sass/Kwf/stylesheets/form/_default-styles.scss
+++ b/sass/Kwf/stylesheets/form/_default-styles.scss
@@ -2,7 +2,6 @@
 @import "compass/utilities/general/clearfix";
 @import "kwf/background-image-dpr2";
 @import "config/default-loading-animation-small";
-@import "compass/css3/box-sizing";
 @import "form/predefined/form-style-default";
 @import "form/predefined/form-style-default-center";
 @import "form/predefined/form-style-center";

--- a/sass/Kwf/stylesheets/form/_input-width.scss
+++ b/sass/Kwf/stylesheets/form/_input-width.scss
@@ -1,9 +1,7 @@
-@import "compass/css3/box-sizing";
-
 @mixin form-input-width($width) {
     .kwfUp-kwfFormFieldWrapper {
-        input, textarea, select, {
-            @include box-sizing(border-box);
+        input, textarea, select {
+            box-sizing: border-box;
             width: 100% !important;
             max-width: $width;
 

--- a/sass/Kwf/stylesheets/image/_loaded-animation.scss
+++ b/sass/Kwf/stylesheets/image/_loaded-animation.scss
@@ -1,6 +1,3 @@
-@import "compass/css3/transition";
-@import "compass/css3/transform";
-
 //fadeIn, fadeInSlideInBottom, fadeInZoom
 
 @mixin loaded-animation($animation-style) {
@@ -15,9 +12,9 @@
             &:not(.webResponsiveImgLoading) {
                 img {
                     opacity: 1;
-                    @include transition-property(all);
-                    @include transition-duration(0.4s);
-                    @include transition-timing-function(ease);
+                    transition-property: all;
+                    transition-duration: 0.4s;
+                    transition-timing-function: ease;
                 }
             }
         }
@@ -26,17 +23,17 @@
             &.webResponsiveImgLoading {
                 img {
                     opacity: 0;
-                    @include transform(translate(0, 20px));
+                    transform: translate(0, 20px);
                 }
             }
 
             &:not(.webResponsiveImgLoading) {
                 img {
                     opacity: 1;
-                    @include transition-property(all);
-                    @include transition-duration(0.4s);
-                    @include transition-timing-function(ease);
-                    @include transform(translate(0, 0));
+                    transition-property: all;
+                    transition-duration: 0.4s;
+                    transition-timing-function: ease;
+                    transform: translate(0, 0);
                 }
             }
         }
@@ -45,17 +42,17 @@
             &.webResponsiveImgLoading {
                 img {
                     opacity: 0;
-                    @include transform(scale(0.95));
+                    transform: scale(0.95);
                 }
             }
 
             &:not(.webResponsiveImgLoading) {
                 img {
                     opacity: 1;
-                    @include transition-property(all);
-                    @include transition-duration(0.4s);
-                    @include transition-timing-function(ease);
-                    @include transform(scale(1));
+                    transition-property: all;
+                    transition-duration: 0.4s;
+                    transition-timing-function: ease;
+                    transform: scale(1);
                 }
             }
         }

--- a/sass/Kwf/stylesheets/kwf/_background-image-dpr2.scss
+++ b/sass/Kwf/stylesheets/kwf/_background-image-dpr2.scss
@@ -5,11 +5,10 @@
     background: url($path + '/' + $file);
   }
 
-  @media (min-device-pixel-ratio: 1.1), (-webkit-min-device-pixel-ratio: 1.1) {
+  @media (min-device-pixel-ratio: 1.1) {
     & {
       background-image: url($path + '/dpr2/' + $file);
       background-size: $width $height;
-      -webkit-background-size: $width $height;
     }
   }
 }

--- a/sass/Kwf/stylesheets/kwf/_loading-animation.scss
+++ b/sass/Kwf/stylesheets/kwf/_loading-animation.scss
@@ -14,15 +14,12 @@
         top: 50%;
         margin-left: -($width / 2);
         margin-top: -($height / 2);
-        -moz-animation: $animationName .5s infinite linear;
-        -webkit-animation: $animationName .5s infinite linear;
         animation: $animationName .5s infinite linear;
 
-        @media (min-device-pixel-ratio: 1.1), (-webkit-min-device-pixel-ratio: 1.1) {
+        @media (min-device-pixel-ratio: 1.1) {
             & {
               background-image: url($path + '/dpr2/' + $file + '.png');
               background-size: $width $height;
-              -webkit-background-size: $width $height;
             }
         }
     }

--- a/sass/Kwf/stylesheets/kwf/css3/_border-radius.scss
+++ b/sass/Kwf/stylesheets/kwf/css3/_border-radius.scss
@@ -1,7 +1,0 @@
-@import "compass/css3/border-radius";
-@import "kwf/css3/pie";
-
-@mixin border-radius-pie ($radius: $default-border-radius, $vertical-radius: false) {
-    @include border-radius($radius, $vertical-radius);
-    @include pie;
-}

--- a/sass/Kwf/stylesheets/kwf/css3/_box-shadow.scss
+++ b/sass/Kwf/stylesheets/kwf/css3/_box-shadow.scss
@@ -1,9 +1,0 @@
-@import "compass/css3/box-shadow";
-@import "kwf/css3/pie";
-
-@mixin box-shadow-pie ($shadow-1: default, $shadow-2: false, $shadow-3: false,
-$shadow-4: false, $shadow-5: false, $shadow-6: false, $shadow-7: false,
-$shadow-8: false, $shadow-9: false, $shadow-10: false) {
-    @include box-shadow($shadow-1, $shadow-2,  $shadow-3,  $shadow-4,  $shadow-5,  $shadow-6,  $shadow-7,  $shadow-8,  $shadow-9,  $shadow-10);
-    @include pie;
-}

--- a/sass/Kwf/stylesheets/kwf/css3/_pie.scss
+++ b/sass/Kwf/stylesheets/kwf/css3/_pie.scss
@@ -1,2 +1,0 @@
-$pie-behavior: url("/assets/css3pie/pie.htc");
-@import "compass/css3/pie";

--- a/sass/Kwf/stylesheets/kwf/legacy/form/_label-34-input-60.scss
+++ b/sass/Kwf/stylesheets/kwf/legacy/form/_label-34-input-60.scss
@@ -1,9 +1,7 @@
-@import "compass/css3/box-sizing";
-
 @mixin label-34-input-60 {
     .kwfField {
         > label {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             margin-right: 6%;
             max-width: 34%;
             min-width: 34%;
@@ -11,8 +9,8 @@
     }
 
     .kwfUp-kwfFormFieldWrapper.kwfUp-hasLabel {
-        input, textarea, select, {
-            @include box-sizing(border-box);
+        input, textarea, select {
+            box-sizing: border-box;
             max-width: 60%;
         }
     }

--- a/sass/Kwf/stylesheets/kwf/legacy/form/_label-X-margin-X-input-X.scss
+++ b/sass/Kwf/stylesheets/kwf/legacy/form/_label-X-margin-X-input-X.scss
@@ -1,9 +1,7 @@
-@import "compass/css3/box-sizing";
-
 @mixin label-X-margin-X-input-X($label, $margin, $input) {
     .kwfField {
         > label {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             margin-right: $margin;
             max-width: $label;
             min-width: $label;
@@ -11,8 +9,8 @@
     }
 
     .kwfUp-kwfFormFieldWrapper.kwfUp-hasLabel {
-        input, textarea, select, {
-            @include box-sizing(border-box);
+        input, textarea, select {
+            box-sizing: border-box;
             max-width: $input;
         }
     }

--- a/sass/Kwf/stylesheets/kwf/legacy/form/_label-center-input-all.scss
+++ b/sass/Kwf/stylesheets/kwf/legacy/form/_label-center-input-all.scss
@@ -2,7 +2,7 @@
     > div.kwfUp-kwcForm > form {
         .kwfUp-kwfFormFieldWrapper {
             > input, textarea, select {
-                @include box-sizing(border-box);
+                box-sizing: border-box;
                 width: 100% !important;
             }
         }

--- a/sass/Kwf/stylesheets/kwf/legacy/form/_label-left-input-all.scss
+++ b/sass/Kwf/stylesheets/kwf/legacy/form/_label-left-input-all.scss
@@ -1,5 +1,3 @@
-@import "compass/css3/box-sizing";
-
 @mixin label-left-input-all {
     > div.kwfUp-kwcForm > form {
         .kwfUp-kwfFormFieldWrapper {
@@ -7,13 +5,13 @@
             width: 100%;
 
             > input, textarea, select {
-                @include box-sizing(border-box);
+                box-sizing: border-box;
                 width: 100% !important;
             }
         }
 
         label {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             display: table-cell;
             vertical-align: top;
             padding-right: 20px;

--- a/sass/Kwf/stylesheets/kwf/legacy/form/_label-top-input-all.scss
+++ b/sass/Kwf/stylesheets/kwf/legacy/form/_label-top-input-all.scss
@@ -2,7 +2,7 @@
     > div.kwfUp-kwcForm > form {
         .kwfUp-kwfFormFieldWrapper {
             > input, textarea, select {
-                @include box-sizing(border-box);
+                box-sizing: border-box;
                 width: 100% !important;
             }
         }

--- a/tests/Kwf/Assets/DependencyScss/file3.scss
+++ b/tests/Kwf/Assets/DependencyScss/file3.scss
@@ -1,4 +1,3 @@
-@import "compass/css3/border-radius";
 body {
-    @include border-radius(3px);
+    border-radius: 3px;
 }

--- a/views/user/master.scss
+++ b/views/user/master.scss
@@ -1,7 +1,5 @@
 @import "compass/utilities/general/clearfix";
 @import "kwf/background-image-dpr2";
-@import "compass/css3/transition";
-@import "compass/css3/box-sizing";
 @import "config/user/master";
 
 $colorIcon: null;
@@ -28,8 +26,6 @@ html {
     body.kwfUp-backendUser {
         .kwfUp-content {
             animation: backendUserFadein 1s, backendUserSlidein 1s;
-            -moz-animation: backendUserFadein 1s, backendUserSlidein 1s; // Firefox
-            -webkit-animation: backendUserFadein 1s, backendUserSlidein 1s; // Safari and Chrome
             animation-timing-function: ease;
         }
     }
@@ -43,39 +39,7 @@ html {
         opacity:1;
     }
 }
-@-moz-keyframes backendUserFadein { // Firefox
-    from {
-        opacity:0;
-    }
-    to {
-        opacity:1;
-    }
-}
-@-webkit-keyframes backendUserFadein { // Safari and Chrome
-    from {
-        opacity:0;
-    }
-    to {
-        opacity:1;
-    }
-}
 @keyframes backendUserSlidein {
-    from {
-        margin-top: -158px;
-    }
-    to {
-        margin-top: -178px;
-    }
-}
-@-moz-keyframes backendUserSlidein {
-    from {
-        margin-top: -158px;
-    }
-    to {
-        margin-top: -178px;
-    }
-}
-@-webkit-keyframes backendUserSlidein {
     from {
         margin-top: -158px;
     }
@@ -100,16 +64,16 @@ body.kwfUp-backendUser {
 
         .kwfUp-innerFrontendLink {
             .kwfUp-front {
-                @include box-sizing(border-box);
+                box-sizing: border-box;
                 text-transform: uppercase;
                 color: $button-color;
                 position: absolute;
                 padding-top: 4px;
                 left: -50px;
                 z-index: 1;
-                @include transition-property(all);
-                @include transition-duration(0.3s);
-                @include transition-timing-function(ease);
+                transition-property: all;
+                transition-duration: 0.3s;
+                transition-timing-function: ease;
             }
 
             .kwfUp-back {
@@ -124,9 +88,9 @@ body.kwfUp-backendUser {
                     font-size: 45px;
                     color: $colorIcon;
                     content: "b";
-                    @include transition-property(all);
-                    @include transition-duration(0.3s);
-                    @include transition-timing-function(ease);
+                    transition-property: all;
+                    transition-duration: 0.3s;
+                    transition-timing-function: ease;
                 }
             }
         }
@@ -249,8 +213,8 @@ body.kwfUp-backendUser {
             height: 40px;
             border: none;
             width: 100%;
-            @include transition-property(all);
-            @include transition-duration(0.25s);
+            transition-property: all;
+            transition-duration: 0.25s;
 
             &:hover {
                 background: none $button-color-hover;


### PR DESCRIPTION
They are no longer necessary because of the autoprefixer that was added in Koala-Framework 4.1.

This also fixes the following issue:
In Koala-Framework 4.2 node-sass was updated to 3.7 which no longer
supports the scss-function "compact". This function is still used in
many compass-mixins which causes node-sass to output invalid css.