### PR TITLE
Fix randomly defect request,

### DIFF
--- a/Kwf/Srpc/Client.php
+++ b/Kwf/Srpc/Client.php
@@ -62,7 +62,8 @@ class Kwf_Srpc_Client
     {
         $httpClientConfig = array(
             'timeout' => $this->_timeout,
-            'persistent' => true
+            'persistent' => true,
+            'adapter' => 'Zend_Http_Client_Adapter_Curl'
         );
         if ($this->_proxy) {
             $httpClientConfig = array_merge($httpClientConfig, $this->_proxy);


### PR DESCRIPTION
curl-adapter solves this problem unknown problem for some unknown reason.
Request for rtr check works for argument-length=5683 but fails
for argument-length=5716