### PR TITLE
Fix randomly defect request,

### DIFF
--- a/Kwf/Srpc/Client.php
+++ b/Kwf/Srpc/Client.php
@@ -64,10 +64,12 @@ class Kwf_Srpc_Client
             'timeout' => $this->_timeout,
             'persistent' => true
         );
-        if ($this->_proxy) {
-            $httpClientConfig = array_merge($httpClientConfig, $this->_proxy);
+        if (extension_loaded('curl')) {
+            $httpClientConfig['adapter'] = 'Zend_Http_Client_Adapter_Curl';
+        } else if ($this->_proxy) {
             $httpClientConfig['adapter'] = 'Zend_Http_Client_Adapter_Proxy';
         }
+        if ($this->_proxy) $httpClientConfig = array_merge($httpClientConfig, $this->_proxy);
         $serverUrl = $this->getServerUrl();
         $httpClient = new Zend_Http_Client($serverUrl, $httpClientConfig);
         $httpClient->setMethod(Zend_Http_Client::POST);


### PR DESCRIPTION
curl-adapter solves this problem unknown problem for some unknown reason.
Request for rtr check works for argument-length=5683 but fails
for argument-length=5716