### PR TITLE
Remove outdated css3 mixins

### DIFF
--- a/sass/Kwf/stylesheets/kwf/css3/_border-radius.scss
+++ b/sass/Kwf/stylesheets/kwf/css3/_border-radius.scss
@@ -1,6 +1,0 @@
-@import "compass/css3/border-radius";
-
-@mixin border-radius-pie ($radius: $default-border-radius, $vertical-radius: false) {
-    @warn '"kwf/css3/border-radius" is deprecated and will be removed in Koala-Framework 5.2.';
-    @include border-radius($radius, $vertical-radius);
-}

--- a/sass/Kwf/stylesheets/kwf/css3/_box-shadow.scss
+++ b/sass/Kwf/stylesheets/kwf/css3/_box-shadow.scss
@@ -1,7 +1,0 @@
-@import "compass/css3/box-shadow";
-
-@mixin box-shadow-pie ($shadow-1: default, $shadow-2: false, $shadow-3: false,
-$shadow-4: false, $shadow-5: false, $shadow-6: false, $shadow-7: false,
-$shadow-8: false, $shadow-9: false, $shadow-10: false) {
-    @warn 'kwf/css3/box-shadow does not work in Koala-Framwork 4.2 and up and must not be used.';
-}

--- a/sass/Kwf/stylesheets/kwf/css3/_pie.scss
+++ b/sass/Kwf/stylesheets/kwf/css3/_pie.scss
@@ -1,2 +1,0 @@
-$pie-behavior: url("/assets/css3pie/pie.htc");
-@import "compass/css3/pie"; 


### PR DESCRIPTION
These mixins are either deprecated or do not work.
Because of the autoprefixer added in 4.1 they can be replaced with normal css.