### PR TITLE
Fix NonAjaxForm submit

### DIFF
--- a/Kwc/Form/NonAjax/Component.defer.js
+++ b/Kwc/Form/NonAjax/Component.defer.js
@@ -4,8 +4,12 @@ var Form = require('kwf/frontend-form/form');
 onReady.onRender('.kwcClass', function form(form) {
     if (!form.get(0).kwcForm) {
         var formObject = new Form(form);
-        formObject.submit = function() {
-            this.el.find('form').submit();
-        };
+        var button = form.find('form button.kwfUp-submit');
+        if (button) {
+            // removing submit-button onclick listener to prevent JS form.submit()
+            // as this does not include the submit-button name/value pair in post-request
+            // which is required for kwc-form to work (does not save if missing)
+            button.off('click.kwfUp-commonjsFrontendFormForm');
+        }
     }
 }, { priority: -10, defer: true }); //initialize form very early, as many other components access it

--- a/commonjs/frontend-form/form.js
+++ b/commonjs/frontend-form/form.js
@@ -88,7 +88,7 @@ var FormComponent = function(form)
 
     var button = form.find('form button.kwfUp-submit');
     if (button) {
-        button.on('click', this.onSubmit.bind(this));
+        button.on('click.kwfUp-commonjsFrontendFormForm', this.onSubmit.bind(this));
     }
 
     $.each(this.fields, (function(i, f) {


### PR DESCRIPTION
Kwc-form needs value from submit button to distinguish between different
buttons clicked in form. (e.g. file-upload button and form-submit button)
this information was lost due to submitting via form.submit().
Fixed problem by removing submit-button onclick-listener to
completely remove js code in submit-process.
It was not desired to remove commonjs/FrontendForm/Form.js because
it also handles initialising form-field js functionality.