### PR TITLE
Return null for parent expression if parent_id is null.

### DIFF
--- a/Kwf/Model/Abstract.php
+++ b/Kwf/Model/Abstract.php
@@ -667,6 +667,9 @@ abstract class Kwf_Model_Abstract implements Kwf_Model_Interface
                 $row = $this->getRow($row[$this->getPrimaryKey()]);
             }
             $reference = $row->getModel()->getReference($expr->getParent());
+            if ($row->{$reference['column']} == null) {
+                return null;
+            }
             $parentModel = $row->getModel()->getReferencedModel($expr->getParent());
             $select = new Kwf_Model_Select();
             $select->whereId($row->{$reference['column']});


### PR DESCRIPTION
This behaviour makes more sense as returning the first row returned
from database. And since $select->whereId(null) throws error it's
also required to make ParentExpression working.