### PR TITLE
Avoid warning when unsing count() on string in php7.3

### DIFF
--- a/Kwc/Abstract.php
+++ b/Kwc/Abstract.php
@@ -135,7 +135,7 @@ abstract class Kwc_Abstract extends Kwf_Component_Abstract
             return array_unique($ret);
 
         } else if ($selectType == 'array' && is_string($class) && count($select) == 1 &&
-            isset($select['componentClass']) && count($select['componentClass']) == 1
+            isset($select['componentClass']) && is_string($select['componentClass'])
         ) {
             //simple case no 3: looking for a single comopnentClass
             foreach (Kwc_Abstract::getSetting($class, 'generators') as $g) {


### PR DESCRIPTION
Der Inhalt von $select['componentClass'] ist (zumindest teilweise) ein string.
Gibt man count() einen string als argument bekommt man ein Warning.

Beispiel:

```
// PHP 7.1
// OK
var_dump(count('some string') == 1); // true     no warning 

// PHP 7.3 
// PHP Warning:  count(): Parameter must be an array or an object that implements Countable
var_dump(count('some string') == 1); // true     but with warning



```