### PR TITLE
Avoid throwing error for component which are not beneath a domain

### DIFF
--- a/Kwf/Component/Data.php
+++ b/Kwf/Component/Data.php
@@ -180,7 +180,8 @@ class Kwf_Component_Data
     public function getDomainComponentId()
     {
         if (!isset($this->_domainComponentIdCache)) { //cache ist vorallem für bei kwfUnserialize nützlich
-            $this->_domainComponentIdCache = $this->getDomainComponent()->componentId;
+            $domainComponent = $this->getDomainComponent();
+            $this->_domainComponentIdCache = $domainComponent ? $domainComponent->componentId : null;
         }
         return $this->_domainComponentIdCache;
     }


### PR DESCRIPTION
Bei Rotary (wo sonst) gibt es Domains, aber auch Content, der für alle Domains gilt und direkt unter root liegt. Das hat mit der bisherigen Implementierung nicht funktioniert.