### PR TITLE
Remove canonical url from Trl_Component

### DIFF
--- a/Kwc/Box/MetaTags/Trl/Component.php
+++ b/Kwc/Box/MetaTags/Trl/Component.php
@@ -28,7 +28,6 @@ class Kwc_Box_MetaTags_Trl_Component extends Kwc_Abstract_Composite_Trl_Componen
     {
         $ret = parent::getTemplateVars($renderer);
         $ret['metaTags'] = $this->_getMetaTags();
-        $ret['canonicalUrl'] = $this->getData()->getAbsoluteUrl();
         return $ret;
     }
 }


### PR DESCRIPTION
It should only be added when needed.
It was removed in the non-trl component in d4b96bc5248ce5c2e91143e398978d66cc6eff59