### PR TITLE
Remove window.open in download-tag

### DIFF
--- a/Kwc/Basic/DownloadTag/Data.php
+++ b/Kwc/Basic/DownloadTag/Data.php
@@ -27,16 +27,4 @@ class Kwc_Basic_DownloadTag_Data extends Kwf_Component_Data
     {
         return $this->url;
     }
-
-    public function getLinkDataAttributes()
-    {
-        $ret = parent::getLinkDataAttributes();
-        $ret['kwc-popup'] = 'blank';
-        return $ret;
-    }
-
-    public function getLinkClass()
-    {
-        return parent::getLinkClass().' kwfUp-kwcPopup';
-    }
 }


### PR DESCRIPTION
This behaviour was to prevent opening the download directly in the
current browser window (even though the we tell the browser to
download the file anyway). Nowadays this workaround should not be
necessary anymore.
Current problem is in mobile-apps when the link is clicked in an
in-app-browser because an empty webview is opened.