### PR TITLE
Allow /admin/component/edit in robots.txt

### DIFF
--- a/Kwf/Util/RobotsTxt.php
+++ b/Kwf/Util/RobotsTxt.php
@@ -5,6 +5,7 @@ class Kwf_Util_RobotsTxt
     {
         $baseUrl = Kwf_Setup::getBaseUrl();
         $contents = "User-agent: *\n".
+            "Allow: $baseUrl/admin/component/edit/\n".
             "Disallow: $baseUrl/admin/\n";
 
         $contents .= "Sitemap: http".(isset($_SERVER['HTTPS']) ? 's' : '')."://"


### PR DESCRIPTION
https://search.google.com/test/mobile-friendly says that all requested resources should be
allowed if they are of importance

Applies to mobile menu, ajax-view