### PR TITLE
Set background-size at normal device-pixel-ratio

### DIFF
--- a/sass/Kwf/stylesheets/kwf/_background-image-dpr2.scss
+++ b/sass/Kwf/stylesheets/kwf/_background-image-dpr2.scss
@@ -1,14 +1,13 @@
 @mixin background-image-dpr2($path, $file, $width, $height, $params:"") {
-  @if $params != "" {
-    background: url($path + '/' + $file) $params;
-  } @else {
-    background: url($path + '/' + $file);
-  }
-
-  @media (min-device-pixel-ratio: 1.1), (min-resolution: 1.1dppx) {
-    & {
-      background-image: url($path + '/dpr2/' + $file);
-      background-size: $width $height;
+    @if $params != "" {
+        background: url($path + '/' + $file) $params;
+    } @else {
+        background: url($path + '/' + $file);
     }
-  }
+
+    background-size: $width $height;
+
+    @media (min-device-pixel-ratio: 1.1), (min-resolution: 1.1dppx) {
+        background-image: url($path + '/dpr2/' + $file);
+    }
 }


### PR DESCRIPTION
This prevents inconsistencies bewteen normal and hi-res screens when
the sizes of the image and the container do not match.