### PR TITLE
Make sure that controllerUrl is absolute

### DIFF
--- a/Kwf/Controller/Action.php
+++ b/Kwf/Controller/Action.php
@@ -80,7 +80,7 @@ abstract class Kwf_Controller_Action extends Zend_Controller_Action
                 $this->_forward('json-login', 'login',
                                     'kwf_controller_action_user', $params);
             } else {
-                $params = array('location' => $this->getRequest()->getPathInfo());
+                $params = array('location' => '/' . ltrim($this->getRequest()->getPathInfo(), '/'));
                 $this->_forward('index', 'login',
                                     'kwf_controller_action_user', $params);
             }

--- a/Kwf/Controller/Action/Auto/Form.php
+++ b/Kwf/Controller/Action/Auto/Form.php
@@ -15,7 +15,7 @@ abstract class Kwf_Controller_Action_Auto_Form extends Kwf_Controller_Action_Aut
         if ($this->_form->getProperties()) {
             $this->view->assign($this->_form->getProperties());
         }
-        $this->view->controllerUrl = $this->getRequest()->getPathInfo();
+        $this->view->controllerUrl = '/' . ltrim($this->getRequest()->getPathInfo(), '/');
         $this->view->xtype = 'kwf.autoform';
     }
 

--- a/Kwf/Controller/Action/Auto/Grid.php
+++ b/Kwf/Controller/Action/Auto/Grid.php
@@ -39,7 +39,7 @@ abstract class Kwf_Controller_Action_Auto_Grid extends Kwf_Controller_Action_Aut
 
     public function indexAction()
     {
-        $this->view->controllerUrl = $this->getRequest()->getPathInfo();
+        $this->view->controllerUrl = '/' . ltrim($this->getRequest()->getPathInfo(), '/');
         if ($this->_getParam('componentId')) {
             $this->view->baseParams = array(
                 'componentId' => $this->_getParam('componentId')

--- a/Kwf/Controller/Action/Auto/ImageGrid.php
+++ b/Kwf/Controller/Action/Auto/ImageGrid.php
@@ -27,7 +27,7 @@ abstract class Kwf_Controller_Action_Auto_ImageGrid extends Kwf_Controller_Actio
 
     public function indexAction()
     {
-        $this->view->controllerUrl = $this->getRequest()->getPathInfo();
+        $this->view->controllerUrl = '/' . ltrim($this->getRequest()->getPathInfo(), '/');
         $this->view->xtype = 'kwf.imagegrid';
     }
 

--- a/Kwf/Controller/Action/Auto/Synctree.php
+++ b/Kwf/Controller/Action/Auto/Synctree.php
@@ -3,9 +3,9 @@
  * This controller is used to display a tree structure.
  *
  * The sync-prefix means that this controller loads all data at once, so children are always loaded.
- * 
  *
- * @package 
+ *
+ * @package
  */
 abstract class Kwf_Controller_Action_Auto_Synctree extends Kwf_Controller_Action_Auto_Abstract
 {
@@ -70,7 +70,7 @@ abstract class Kwf_Controller_Action_Auto_Synctree extends Kwf_Controller_Action
     */
     public function indexAction()
     {
-        $this->view->controllerUrl = $this->getRequest()->getPathInfo();
+        $this->view->controllerUrl = '/' . ltrim($this->getRequest()->getPathInfo(), '/');
         $this->view->xtype = 'kwf.autotreesync';
     }
 

--- a/Kwf/Controller/Action/User/UsersController.php
+++ b/Kwf/Controller/Action/User/UsersController.php
@@ -180,7 +180,7 @@ class Kwf_Controller_Action_User_UsersController extends Kwf_Controller_Action_A
     public function indexAction()
     {
         $config = array(
-            'controllerUrl' => $this->getRequest()->getPathInfo()
+            'controllerUrl' => '/' . ltrim($this->getRequest()->getPathInfo(), '/')
         );
         if (Kwf_Registry::get('acl')->has('kwf_user_log')) {
             $config['logControllerUrl'] = '/kwf/user/log';


### PR DESCRIPTION
Wrong behaviour introduced in https://github.com/koala-framework/koala-framework/pull/881/files

Error occured in XLS-Export when the non absolute url was called in an I-Frame
(XHR-Requests were not affected)