### PR TITLE
fix mobile menu cache problem

### DIFF
--- a/Kwc/Menu/Mobile/Events.php
+++ b/Kwc/Menu/Mobile/Events.php
@@ -49,29 +49,39 @@ class Kwc_Menu_Mobile_Events extends Kwc_Abstract_Events
 
     public function onPageChanged(Kwf_Events_Event_Abstract $event)
     {
-        $this->_deleteCache($event);
+        $this->_deleteCacheByEvent($event);
     }
 
     public function onPageChangedRecursive(Kwf_Component_Event_Component_RecursiveAbstract $event)
     {
-        $this->_deleteCache($event);
+        $this->_deleteCacheByEvent($event);
     }
 
-    private function _deleteCache($event)
+    private function _deleteCacheByEvent($event)
     {
         $d = $event->component->getParentPage();
         if (!$d) {
             $d = $event->component->getSubroot();
         }
         while ($d) {
-            if (Kwc_Abstract::getFlag($d->componentClass, 'subroot') || $d->componentId == 'root') {
-                Kwf_Cache_Simple::delete('kwcMenuMobile-root-'.$d->componentId.'-'.$this->_class);
-                break;
-            } else if ($d->isPage) {
-                Kwf_Cache_Simple::delete('kwcMenuMobile-'.$d->componentId);
-                break;
-            }
+            if ($this->_deleteCache($d)) break;
             $d = $d->parent;
         }
+    }
+
+    private function _deleteCache(Kwf_Component_Data $d, $deleteCacheForParent = true)
+    {
+        if (Kwc_Abstract::getFlag($data->componentClass, 'subroot') || $data->componentId == 'root') {
+            Kwf_Cache_Simple::delete('kwcMenuMobile-root-'.$data->componentId.'-'.$this->_class);
+
+            return true;
+        } else if ($data->isPage) {
+            Kwf_Cache_Simple::delete('kwcMenuMobile-'.$data->componentId);
+            if ($deleteCacheForParent) $this->_deleteCache(($p = $data->getParentPage()) ? $p : $data->getSubroot(), false);
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
if a subpage is available, the submenu transition is available, but if you hide all subpages then the transition is still working which is wrong
because of that we have to delete the cache of the parent page too to disable the transition for the submenu