### PR TITLE
Improve performance for Db_Row->__get()

### DIFF
--- a/Kwf/Model/Db.php
+++ b/Kwf/Model/Db.php
@@ -58,7 +58,7 @@ class Kwf_Model_Db extends Kwf_Model_Abstract
 
     public function getColumnType($col)
     {
-        if (isset($this->_columnTypes[$col])) {
+        if (array_key_exists($col, $this->_columnTypes)) {
             return $this->_columnTypes[$col];
         }
         $info = $this->getTable()->info();


### PR DESCRIPTION
by checking with array_key_exists instead of isset because if type is
not defined in _getTypeFromDbType null is cached.