### PR TITLE
Since Googlemap v3.37 and Koalaframework 5.1, the mapimages couldn't load in IE11.

### DIFF
--- a/commonjs/google-map/loader.js
+++ b/commonjs/google-map/loader.js
@@ -1,4 +1,5 @@
 var apiKeys = require('kwf-webpack/loader/google-maps-api-key!');
+require('core-js/es6/symbol');
 var t = require('kwf/commonjs/trl');
 var isLoaded = false;
 var isCallbackCalled = false;


### PR DESCRIPTION
Without the symbol-polyfill, the mapimages-urls are wrong in IE11, because of an undefined value in it. As a result, the images can't be loaded. There is an open issuetracker for this problem https://stackoverflow.com/questions/57623843/googlemaps-sorry-we-have-no-imagery-here-in-internetexplorer-11/58019951#58019951 and https://issuetracker.google.com/issues/139888746