### PR TITLE
Doublecheck parentData and reset if necessary

### DIFF
--- a/Kwc/Root/Category/Generator.php
+++ b/Kwc/Root/Category/Generator.php
@@ -345,6 +345,10 @@ class Kwc_Root_Category_Generator extends Kwf_Component_Generator_Abstract
     {
         $page = $this->_getPageData($id);
 
+        if ($parentData && isset($page['parent_id']) && $page['parent_id'] != $parentData->id) {
+            $parentData = null;
+        }
+
         if (!$parentData || ($parentData->componentClass == $this->_class && $page['parent_id'])) {
             $parentData = $page['parent_id'];
         }


### PR DESCRIPTION
Because of page-history it's possible that pageData is returned
even though the parentData is not valid. Without this commit the
"wrong" parentData was set and the exactMatch-value in Kwf_Setup
was not set to false.