### PR TITLE
Set name for not-found and access-denies pages

### DIFF
--- a/Kwc/Errors/Component.php
+++ b/Kwc/Errors/Component.php
@@ -7,11 +7,13 @@ class Kwc_Errors_Component extends Kwc_Abstract
         $ret['contentSender'] = 'Kwc_Errors_ContentSender';
         $ret['generators']['accessDenied'] = array(
             'class' => 'Kwf_Component_Generator_Page_Static',
-            'component' => 'Kwc_Errors_AccessDenied_Component'
+            'component' => 'Kwc_Errors_AccessDenied_Component',
+            'name' => trlKwfStatic('Access denied'),
         );
         $ret['generators']['notFound'] = array(
             'class' => 'Kwf_Component_Generator_Page_Static',
-            'component' => 'Kwc_Errors_NotFound_Component'
+            'component' => 'Kwc_Errors_NotFound_Component',
+            'name' => trlKwfStatic('Not found'),
         );
         $ret['flags']['noIndex'] = true;
         $ret['flags']['skipFulltextRecursive'] = true;


### PR DESCRIPTION
This name will be shown in the page title and breadcrumbs instead of the component-key.