### PR TITLE
fix touchevent deprecation of modernizr

### DIFF
--- a/commonjs/double-tap-to-go.js
+++ b/commonjs/double-tap-to-go.js
@@ -1,5 +1,3 @@
-// @require ModernizrTouchevents
-
 var onReady = require('kwf/on-ready');
 var $ = require('jQuery');
 
@@ -56,7 +54,7 @@ var DoubleTapToGo = function(el, params) {
         return;
     }
 
-    if (Modernizr.touchevents) {
+    if ('ontouchstart' in window || navigator.msMaxTouchPoints) {
         $.each(el, function(i, element) {
             if ($(element).hasClass('kwfDoubleTapHandler')) return;
 


### PR DESCRIPTION
remove touchevent test of modernizr because it gets removed in 4.0 modernizr in the future according to the (README.md) but already was removed in 3.8 