### PR TITLE
Restrict to compatible modernizr version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
             "browser-pack": "~5.0.1",
             "module-deps": "~3.8.0",
             "JSONStream": "~1.0.4",
-            "modernizr": "^3.0.0",
+            "modernizr": "^3.0.0 <3.8.0",
             "postcss": "~5.0.13",
             "es6-promise": "~3.0.2",
             "css-selectors-count": "~1.0.1",


### PR DESCRIPTION
Modernizr 3.8 deprecates Modernizr.touch and makes build possibly failing
See https://github.com/Modernizr/Modernizr/pull/2472
Removed in Koala 4.5: https://github.com/koala-framework/koala-framework/pull/1016/files