### PR TITLE
Fix wrong interpretation of enable error logging

### DIFF
--- a/Kwf/Exception/Abstract.php
+++ b/Kwf/Exception/Abstract.php
@@ -44,7 +44,7 @@ abstract class Kwf_Exception_Abstract extends Exception
     public static function isLogEnabled()
     {
         try {
-            if (isset(self::$logErrors)) return !self::$logErrors;
+            if (isset(self::$logErrors)) return !!self::$logErrors;
             return Kwf_Config::getValue('debug.error.log');
         } catch (Exception $e) {
             return true;


### PR DESCRIPTION
Is used in Kwf_Util_Wirecard::processIpn()