### PR TITLE
Deactivate csrf-check for Mobile Menu

### DIFF
--- a/Kwc/Menu/Mobile/Controller.php
+++ b/Kwc/Menu/Mobile/Controller.php
@@ -86,6 +86,11 @@ class Kwc_Menu_Mobile_Controller extends Kwf_Controller_Action
         return true;
     }
 
+    protected function _validateCsrf()
+    {
+        // Not necessary for Frontend
+    }
+
     protected function _getChildPages()
     {
         $category = Kwc_Abstract::getSetting($this->_getParam('class'), 'level');


### PR DESCRIPTION
Browser can load mobile menu even though e.g. Referer-Header is empty