### PR TITLE
Fix writing languages.json

### DIFF
--- a/Kwf/Util/Build/Types/Trl.php
+++ b/Kwf/Util/Build/Types/Trl.php
@@ -37,7 +37,7 @@ class Kwf_Util_Build_Types_Trl extends Kwf_Util_Build_Types_Abstract
             throw $e;
         }
 
-        $langs = array_unique($langs);
+        $langs = array_values(array_unique($langs));
 
         //used by webpack
         file_put_contents('build/trl/languages.json', json_encode($langs));


### PR DESCRIPTION
If keys aren't in an ascending order php produces an object instead of an array in json_encode