### PR TITLE
Fix wrong encoded redirect urls

### DIFF
--- a/Kwc/User/Activate/Component.php
+++ b/Kwc/User/Activate/Component.php
@@ -41,7 +41,7 @@ class Kwc_User_Activate_Component extends Kwc_Abstract_Composite_Component
 
             $redirectBackUrl = Kwf_Setup::getBaseUrl().'/';
             $f = new Kwf_Filter_StrongRandom();
-            $state = 'activate.'.$postData['redirectAuth'].'.'.$f->filter(null).'.'.$postData['code'].'.'.$redirectBackUrl;
+            $state = 'activate.'.$postData['redirectAuth'].'.'.$f->filter(null).'.'.$postData['code'].'.'.urlencode(str_replace('.', 'kwfdot', $redirectBackUrl));
 
             //save state in namespace to validate it later
             $ns = new Kwf_Session_Namespace('kwf-login-redirect');

--- a/Kwc/User/Login/Component.php
+++ b/Kwc/User/Login/Component.php
@@ -34,7 +34,7 @@ class Kwc_User_Login_Component extends Kwc_Abstract_Composite_Component
             $redirectBackUrl = $_GET['redirect'];
 
             $f = new Kwf_Filter_StrongRandom();
-            $state = 'login.'.$postData['redirectAuth'].'.'.$f->filter(null).'.'.str_replace('.', 'kwfdot', $redirectBackUrl);
+            $state = 'login.'.$postData['redirectAuth'].'.'.$f->filter(null).'.'.urlencode(str_replace('.', 'kwfdot', $redirectBackUrl));
 
             //save state in namespace to validate it later
             $ns = new Kwf_Session_Namespace('kwf-login-redirect');

--- a/Kwf/Controller/Action/User/BackendActivateController.php
+++ b/Kwf/Controller/Action/User/BackendActivateController.php
@@ -129,8 +129,7 @@ class Kwf_Controller_Action_User_BackendActivateController extends Kwf_Controlle
         }
 
         $f = new Kwf_Filter_StrongRandom();
-        $state = 'activate.'.$authMethod.'.'.$f->filter(null).'.'.$this->_getParam('code').'.'.Kwf_Setup::getBaseUrl().'/kwf/welcome';
-
+        $state = 'activate.'.$authMethod.'.'.$f->filter(null).'.'.$this->_getParam('code').'.'.urlencode(str_replace('.', 'kwfdot', Kwf_Setup::getBaseUrl().'/kwf/welcome'));
         //save state in namespace to validate it later
         $ns = new Kwf_Session_Namespace('kwf-login-redirect');
         $ns->state = $state;

--- a/Kwf/Controller/Action/User/BackendLoginController.php
+++ b/Kwf/Controller/Action/User/BackendLoginController.php
@@ -101,7 +101,7 @@ class Kwf_Controller_Action_User_BackendLoginController extends Kwf_Controller_A
         }
 
         $f = new Kwf_Filter_StrongRandom();
-        $state = 'login.'.$authMethod.'.'.$f->filter(null).'.'.str_replace('.', 'kwfdot', $this->_getParam('redirect'));
+        $state = 'login.'.$authMethod.'.'.$f->filter(null).'.'.urlencode(str_replace('.', 'kwfdot', $this->_getParam('redirect')));
 
         //save state in namespace to validate it later
         $ns = new Kwf_Session_Namespace('kwf-login-redirect');


### PR DESCRIPTION
Url in html does not need to be url-encoded, so remove this step. $_GET
is always url-decoded so we need to encode it again before adding it to
state parameter.