### PR TITLE
Params in html do not need to be urlencoded

### DIFF
--- a/Kwc/User/Login/Plugin.php
+++ b/Kwc/User/Login/Plugin.php
@@ -7,7 +7,8 @@ class Kwc_User_Login_Plugin extends Kwf_Component_Plugin_Abstract
     {
         if (strpos($output, '%redirect%') !== false) {
             $r = isset($_GET['redirect']) ? $_GET['redirect'] : '';
-            $output = str_replace('%redirect%', Kwf_Util_HtmlSpecialChars::filter(urlencode($r)), $output);
+            // this replace is only meant for value attribute in input-tag
+            $output = str_replace('%redirect%', Kwf_Util_HtmlSpecialChars::filter($r), $output);
         }
         return $output;
     }


### PR DESCRIPTION
as this step is done by the browser on submit or get, resulting in
double urlencoding leading to problems.