### PR TITLE
Allow build to be split in Component Classes

### DIFF
--- a/Kwc/Box/Assets/Component.php
+++ b/Kwc/Box/Assets/Component.php
@@ -19,7 +19,13 @@ class Kwc_Box_Assets_Component extends Kwc_Abstract
         $ret = parent::getTemplateVars($renderer);
         $ret['language'] = $this->getData()->getLanguage();
         $ret['subroot'] = $this->getData()->getSubroot();
-        $ret['assetsPackages'] = array('Frontend');
+        $ret['assetsPackages'] = array(Kwf_Config::getValue('kwc.rootComponent'));
+        foreach (Kwf_Config::getValueArray('assets.componentPackages') as $componentPackage) {
+            $classes = Kwf_Component_Settings::getComponentClassesOfStartingClass($componentPackage);
+            if (in_array($this->getData()->getPage()->componentClass, $classes)) {
+                $ret['assetsPackages'][] = $componentPackage;
+            }
+        }
         $ret['kwfUp'] = Kwf_Config::getValue('application.uniquePrefix') ? Kwf_Config::getValue('application.uniquePrefix').'-' : '';
         return $ret;
     }

--- a/Kwf/Component/Settings.php
+++ b/Kwf/Component/Settings.php
@@ -480,6 +480,13 @@ class Kwf_Component_Settings
         return $ret;
     }
 
+    public static function getComponentClassesOfStartingClass($startingClass)
+    {
+        $componentClasses = array($startingClass);
+        self::_getChildComponentClasses($componentClasses, $startingClass);
+        return $componentClasses;
+    }
+
     private static function _getChildComponentClasses(&$componentClasses, $class)
     {
         $tFull = microtime(true);

--- a/Kwf/Util/Build/Types/ComponentSettings.php
+++ b/Kwf/Util/Build/Types/ComponentSettings.php
@@ -43,7 +43,7 @@ class Kwf_Util_Build_Types_ComponentSettings extends Kwf_Util_Build_Types_Abstra
         Kwf_Component_Layout_Abstract::_buildAll($componentClasses);
 
         echo "component-assets...\n";
-        Kwf_Component_Assets::build(Kwf_Component_Data_Root::getComponentClass());
+        Kwf_Component_Assets::build();
     }
 
     private function _checkSettings($settingName, $settings)

--- a/node_modules_build/kwf-webpack/config/webpack.kwc.config.js
+++ b/node_modules_build/kwf-webpack/config/webpack.kwc.config.js
@@ -3,35 +3,41 @@ const Config = require("webpack-config").Config;
 const TrlHtmlWebpackPlugin = require("../trl/trl-html-webpack-plugin");
 const fetchLanguages = require("../loader/fetch-languages");
 const fetchKwfConfig = require("./fetch-kwf-config");
+const fs = require('fs');
 
 const kwfConfig = fetchKwfConfig();
 const devBuild = !!process.env.KWF_BUILD_DEV;
+const packageClasses = JSON.parse(fs.readFileSync('temp/component-assets-build/package-classes.json', 'utf-8'));
 
 const entry = {
     Admin: ["core-js/es6/promise", require.resolve("../loader/ini-loader") + "?dep=AdminMain!"],
-    Frontend: ["core-js/es6/promise", require.resolve("../loader/ini-loader") + "?dep=Frontend!"],
 };
+packageClasses.forEach(function (packageClass) {
+    entry[packageClass] = ["core-js/es6/promise", require.resolve("../loader/ini-loader") + "?dep=" + packageClass + "!"]
+});
+
 if (kwfConfig["webpack-dev-server-url"] && devBuild) {
-    entry.Frontend.push("webpack-dev-server/client?" + kwfConfig["webpack-dev-server-url"]);
+    entry[packageClasses[packageClasses.length - 1]].push("webpack-dev-server/client?" + kwfConfig["webpack-dev-server-url"]);
 }
 
 const plugins = [];
 fetchLanguages().forEach(language => {
-    plugins.push(
-        new TrlHtmlWebpackPlugin({
-            filename: "Frontend." + language + ".html",
-            chunks: ["Frontend"],
-            templateContent: "",
-            inject: "head",
-            language: language,
-            hash: true,
-        }),
-    );
-
+    packageClasses.forEach(function (packageClass) {
+        plugins.push(
+            new TrlHtmlWebpackPlugin({
+                filename: packageClass + "." + language + ".html",
+                chunks: [packageClass],
+                templateContent: "",
+                inject: "head",
+                language: language,
+                hash: true,
+            }),
+        );
+    });
     plugins.push(
         new TrlHtmlWebpackPlugin({
             filename: "Admin." + language + ".html",
-            chunks: ["Frontend", "Admin"],
+            chunks: packageClasses.concat("Admin"),
             templateContent: "",
             inject: "head",
             language: language,

--- a/node_modules_build/kwf-webpack/config/webpack.kwf.config.js
+++ b/node_modules_build/kwf-webpack/config/webpack.kwf.config.js
@@ -162,5 +162,5 @@ module.exports = {
         headers: {
             "Access-Control-Allow-Origin": "*",
         },
-    },
+    }
 };

--- a/node_modules_build/kwf-webpack/loader-kwc/component-assets-loader.js
+++ b/node_modules_build/kwf-webpack/loader-kwc/component-assets-loader.js
@@ -21,8 +21,9 @@ module.exports = function(source, map) {
     }
     */
 
-    this.addDependency(process.cwd()+'/temp/component-assets-build/assets.json');
-    const componentAssets = JSON.parse(fs.readFileSync(process.cwd()+'/temp/component-assets-build/assets.json'));
+    filename = process.cwd()+'/temp/component-assets-build/assets-' + query.dep + '.json';
+    this.addDependency(filename);
+    const componentAssets = JSON.parse(fs.readFileSync(filename));
 
 
     var ret = '';
@@ -33,7 +34,7 @@ module.exports = function(source, map) {
     }
 
     if (!loadDefer) {
-        var url = require.resolve('./component-assets-loader')+"?defer=1!";
+        var url = require.resolve('./component-assets-loader')+"?dep=" + query.dep + "&defer=1!";
         ret += "require.ensure('"+url+"', function() { require('"+url+"'); });\n;";
     }
 

--- a/node_modules_build/kwf-webpack/loader/ini-loader.js
+++ b/node_modules_build/kwf-webpack/loader/ini-loader.js
@@ -14,6 +14,8 @@ const configIni = ini.parse(fs.readFileSync('config.ini', 'utf-8'));
 const uniquePrefix = configIni.production['application.uniquePrefix'];
 
 module.exports = function(source, map) {
+    var packageClasses = JSON.parse(fs.readFileSync('temp/component-assets-build/package-classes.json', 'utf-8'));
+
     var data = this.options;
 
     var query = loaderUtils.parseQuery(this.query);
@@ -31,6 +33,10 @@ module.exports = function(source, map) {
     }
 
     function processDependencies() {
+        if (packageClasses.indexOf(query.dep) !== -1) {
+            dependencies[query.dep+'.dep'] = ['Components'];
+        }
+
         if (!dependencies[query.dep+'.files'] && !dependencies[query.dep+'.dep']) {
             console.log(dependencies);
             console.log(query.dep);
@@ -44,7 +50,13 @@ module.exports = function(source, map) {
             dependencies[query.dep+'.dep'].forEach(function(i) {
                 i = i.replace(/ +$/g,"");
                 if (i == 'Components') {
-                    ret += "require('"+require.resolve('../loader-kwc/component-assets-loader')+"?defer=0!');\n;";
+                    if (query.dep == 'Frontend') {
+                        packageClasses.forEach(function (packageClass) {
+                            ret += "require('"+require.resolve('../loader-kwc/component-assets-loader')+"?dep=" + query.dep + "&defer=0!');\n;";
+                        });
+                    } else {
+                        ret += "require('"+require.resolve('../loader-kwc/component-assets-loader')+"?dep=" + query.dep + "&defer=0!');\n;";
+                    }
                 } else if (i == 'ComponentsAdmin') {
                     ret += "require('"+require.resolve('../loader-kwc/component-admin-assets-loader')+"!');\n;"
                 } else if (i == 'KwfDynamicAssetsVersion') {


### PR DESCRIPTION
Hauptdependency für das Frontend ist die Root_Component, das ersetzt im Prinzip das Frontend-Dependency. Zusätzlich kann man (optional) in der config.ini zusätzliche Dependencies angeben, zb:
`assets.componentPackages[] = Paragraphs_Component`
Beim Builden werden gibt es dann zwei Entries für Root_Component und Paragraphs_Component, in Root_Component ist nur das drinnen, was in Paragraphs_Component nicht drinnen ist.
Dependency Frontend gibts nur noch als logische Einheit in dependencies.ini und wird entsprechend im ini-loader nach Root_Component und Paragraphs_Component aufgelöst.
Die Assets-Box schaut nach, welche Dependencies sie braucht und gibt nur die entsprechenden aus. Damit werden zB. auf nicht Paragraphs-Seiten keine Paragraphs-Dependencies geladen.