### PR TITLE
Implement union child expression

### DIFF
--- a/Kwf/Model/Union.php
+++ b/Kwf/Model/Union.php
@@ -119,6 +119,13 @@ class Kwf_Model_Union extends Kwf_Model_Abstract
             }
         } else if ($expr instanceof Kwf_Model_Select_Expr_Sql) {
             return $expr;
+        } else if ($expr instanceof Kwf_Model_Select_Expr_Child_Contains) {
+            $depRules = array_keys($targetModel->getDependentModels());
+            if (in_array($expr->getChild(), $depRules)) {
+                return $expr;
+            } else {
+                return null;
+            }
         } else {
             throw new Kwf_Exception_NotYetImplemented();
         }


### PR DESCRIPTION
Only apply for models with existing dependent-rule. Return null for
others to don't lock them out (if needed it can be done with other
select statements)