### PR TITLE
Implement union-model specific if-expression

### DIFF
--- a/Kwf/Model/Union.php
+++ b/Kwf/Model/Union.php
@@ -126,6 +126,18 @@ class Kwf_Model_Union extends Kwf_Model_Abstract
             } else {
                 return null;
             }
+        } else if ($expr instanceof Kwf_Model_Select_Expr_If) {
+            if ($expr->getIf() instanceof Kwf_Model_Select_Expr_StartsWith
+                && $expr->getIf()->getField() == $this->getPrimaryKey()
+            ) {
+                if ($expr->getIf()->getValue() == $modelKey) {
+                    return $expr->getThen();
+                } else {
+                    return $expr->getElse();
+                }
+            } else {
+                throw new Kwf_Exception_NotYetImplemented();
+            }
         } else {
             throw new Kwf_Exception_NotYetImplemented();
         }


### PR DESCRIPTION
this way it's possible to make model-specific queries. This does not
work for deeper levels of if-expressions. To implement switch-like
behaviour for a union-model with more than two mixed models use
boolean-expression=true as else statement and define the model-specific
expressions on the same level:
if (model1) ? model1-specific-expression : true;
if (model2) ? model2-specific-expression : true;
if (model3) ? model3-specific-expression : true;

required for pobatis to filter for domain. kwf-users do have only one
domain, pn-users do have multiple domains. There is also a different
database structure required for pn-users (pn-users => functions
(containing domain and company)).