### PR TITLE
Fix Kwf_Form_Field_ImageViewer declaration

### DIFF
--- a/Kwf/Form/Field/ImageViewer.php
+++ b/Kwf/Form/Field/ImageViewer.php
@@ -17,7 +17,7 @@ class Kwf_Form_Field_ImageViewer extends Kwf_Form_Field_Abstract
         return $this->setProperty('ruleKey', $ruleKey);
     }
 
-    public function load($row)
+    public function load($row, $postData = array())
     {
         $data = array(
             'imageUrl' => false,


### PR DESCRIPTION
Fix error

> Declaration of Kwf_Form_Field_ImageViewer::load($row) should be compatible with Kwf_Form_Field_Abstract::load($row, $postData = Array)