### PR TITLE
Revert "Do not encode null value as it results in 'null'"

### DIFF
--- a/Kwf_js/Auto/FormPanel.js
+++ b/Kwf_js/Auto/FormPanel.js
@@ -271,7 +271,7 @@ Kwf.Auto.FormPanel = Ext2.extend(Kwf.Binding.AbstractPanel, {
         var params = this.getForm().getValues();
         params = Ext2.apply(params, this.getBaseParams());
         for (var i in params) {
-            if (typeof params[i] == 'object' && params[i] !== null) {
+            if (typeof params[i] == 'object') {
                 params[i] = Ext2.encode(params[i]);
             } else if (typeof params[i] == 'boolean') {
                 params[i] = params[i] ? '1' : '0';


### PR DESCRIPTION
Reverts koala-framework/koala-framework#1029

This causes null-params to not be sent at all in Ext.Ajax requests, which for example results in select "no selection" not to be sent to json-save.