### PR TITLE
Throw CC-Event for onParentChanged only when newParent and oldParent …

### DIFF
--- a/Kwc/Chained/Abstract/Component.php
+++ b/Kwc/Chained/Abstract/Component.php
@@ -243,6 +243,7 @@ abstract class Kwc_Chained_Abstract_Component extends Kwc_Abstract
             }
         }
         if (!$subrootReached) return null;
+        if (!isset($chainedData->chained)) return null;
         if ($chainedData->chained->componentId != $c->componentId) return null; // To avoid getting results when called with an already chained component
         $ret = $chainedData;
         if (is_array($select)) {

--- a/Kwc/Chained/Cc/Events.php
+++ b/Kwc/Chained/Cc/Events.php
@@ -222,10 +222,12 @@ class Kwc_Chained_Cc_Events extends Kwc_Chained_Abstract_Events
         foreach ($chained as $i) {
             $newParent = Kwc_Chained_Cc_Component::getChainedByMaster($event->newParent, $i, $select);
             $oldParent = Kwc_Chained_Cc_Component::getChainedByMaster($event->oldParent, $i, $select);
-            $eventCls = get_class($event);
-            $this->fireEvent(
-                new $eventCls($this->_class, $i, $newParent, $oldParent)
-            );
+            if ($newParent && $oldParent) {
+                $eventCls = get_class($event);
+                $this->fireEvent(
+                    new $eventCls($this->_class, $i, $newParent, $oldParent)
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
…exist in CC

Error occured in a web with CC and additional CopyTarget-Components. When
moving a page which is copied Kwc_Chained_Cc_Events::onPageParentChanged()
tried to get the chained components for old- and newParent which do not
exist.