### PR TITLE
Add padding to headerIcon column to avoid text overlapping the icon

### DIFF
--- a/Kwf_js/Grid/GridView.js
+++ b/Kwf_js/Grid/GridView.js
@@ -8,7 +8,8 @@ Ext2.grid.GridView.prototype.getColumnStyle = function(col, isHeader){
     if (isHeader && this.cm.config[col].headerIcon) {
         style += String.format('background-image: url({0}); '+
                                'background-repeat: no-repeat; '+
-                               'background-position: 5px 4px;',
+                               'background-position: 5px 4px;'+
+                               'padding: 0 0 0 20px;',
                                this.cm.config[col].headerIcon);
     }
     return style;


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/5096366/99798450-5a1a5880-2b31-11eb-9dc5-5b72ee6f9e1e.png)
