### PR TITLE
Change Wirecard to Qenta

### DIFF
--- a/Kwc/Shop/Cart/Checkout/Payment/Wirecard/ConfirmLink/Component.php
+++ b/Kwc/Shop/Cart/Checkout/Payment/Wirecard/ConfirmLink/Component.php
@@ -63,7 +63,7 @@ class Kwc_Shop_Cart_Checkout_Payment_Wirecard_ConfirmLink_Component extends Kwc_
         $requestFingerprintSeed  .= $params['requestFingerprintOrder'];
         $params['requestFingerprint'] = md5($requestFingerprintSeed);
 
-        $initURL = "https://checkout.wirecard.com/page/init.php";
+        $initURL = "https://api.qenta.com/page/init.php";
         $ret = "<form action=\"$initURL\" method=\"post\" name=\"form\">\n";
         foreach ($params as $k=>$i) {
         if ($k == 'secret') continue;


### PR DESCRIPTION
Wir haben bei Babytuch ein Mail bekommen, dass die Wirecard API mit 22.01.2021 abgedreht und von der Qenta API ersetzt wird. Dabei ist nur die Domain zu tauschen, der Rest der API bleibt gleich.