### PR TITLE
Prevent error when passing null into array_merge

### DIFF
--- a/Kwc/Paging/Abstract/Component.php
+++ b/Kwc/Paging/Abstract/Component.php
@@ -292,9 +292,12 @@ class Kwc_Paging_Abstract_Component extends Kwc_Abstract
 
     public function getViewCacheSettings()
     {
-        return array_merge(
-            parent::getViewCacheSettings(),
-            $this->getData()->parent->getComponent()->getViewCacheSettings()
-        );
+        $ret = parent::getViewCacheSettings();
+
+        if ($parentViewCacheSettings = $this->getData()->parent->getComponent()->getViewCacheSettings()) {
+            $ret = array_merge($ret, $parentViewCacheSettings);
+        }
+
+        return $ret;
     }
 }


### PR DESCRIPTION
ViewCacheSettings of parent can be null.