### PR TITLE
Fix image-bottom-padding bug without display:block

### DIFF
--- a/Kwc/Basic/ImageEnlarge/Mail.html.tpl
+++ b/Kwc/Basic/ImageEnlarge/Mail.html.tpl
@@ -1,6 +1,6 @@
 <?php if ($this->baseUrl) { ?>
     <?=$this->component($this->linkTag)?>
-        <?=$this->image($this->data, '', array('class' => $this->imgCssClass, 'border' => '0', 'style' => 'display: block;'))?>
+        <?=$this->image($this->data, '', array('class' => $this->imgCssClass, 'border' => '0', 'style' => 'display: inline-block;vertical-align: top'))?>
     <?php if ($this->hasContent($this->linkTag)) { ?>
         </a>
     <?php } ?>


### PR DESCRIPTION
display:block does not allow easy center image.
display:inline-block + vertical-align:top does also solve image
padding-bottom problem but also allows centering image