### PR TITLE
Revert "properly delete removed page from Fulltext MetaModel"

### DIFF
--- a/Kwf/Controller/Action/Cli/Web/FulltextController.php
+++ b/Kwf/Controller/Action/Cli/Web/FulltextController.php
@@ -205,8 +205,6 @@ class Kwf_Controller_Action_Cli_Web_FulltextController extends Kwf_Controller_Ac
             if (!$newDoc) {
                 //this can happen (if there is no content)
                 Kwf_Util_Fulltext_Backend_Abstract::getInstance()->deleteDocument($subroot, $componentId);
-                $row = $pagesMetaModel->getRow($componentId);
-                if ($row) $row->delete();
                 continue;
             }
             if (trim($newDoc['content']) != trim($docContent)) {


### PR DESCRIPTION
This reverts commit 5584428d3298869615f8b0c0ca3fd0cd353588f3.

Mit der bisherigen Lösung wurden Seiten ohne Content (zB nur mit einem iFrame) aus der kwf_pages_meta Tabelle gelöscht, wodurch sie auch nicht mehr in der Sitemap waren.