### PR TITLE
Fix trl version of mobile-menu

### DIFF
--- a/Kwc/Menu/Mobile/Controller.php
+++ b/Kwc/Menu/Mobile/Controller.php
@@ -174,9 +174,10 @@ class Kwc_Menu_Mobile_Controller extends Kwf_Controller_Action
                     }
                 }
 
-
-                if (Kwc_Abstract::getSetting($this->_getParam('class'), 'showSelectedPageInList') && !empty($ret[$i]['children']) &&
-                    !is_instance_of($page->componentClass, 'Kwc_Basic_LinkTag_FirstChildPage_Component')) {
+                if (Kwc_Abstract::getSetting($this->_getParam('class'), 'showSelectedPageInList') && !empty($ret[$i]['children'])
+                    && !is_instance_of($page->componentClass, 'Kwc_Basic_LinkTag_FirstChildPage_Component')
+                    && !is_instance_of($page->componentClass, 'Kwc_Basic_LinkTag_FirstChildPage_Trl_Component')
+                ) {
                     array_unshift($ret[$i]['children'], array(
                         'name' => $pageData['name'],
                         'url' => $pageData['url'],


### PR DESCRIPTION
does not correctly detect FirstChildPage and displays link to this kind
of parent-page in navigation next to children.