### PR TITLE
Avoid usage of password column in grid-controller

### DIFF
--- a/Kwf/Controller/Action/User/UsersController.php
+++ b/Kwf/Controller/Action/User/UsersController.php
@@ -60,7 +60,7 @@ class Kwf_Controller_Action_User_UsersController extends Kwf_Controller_Action_A
              $this->_columns->add(new Kwf_Grid_Column('language', trlKwf('lang'), 30));
         }
 
-        $this->_columns->add(new Kwf_Grid_Column('password', trlKwf('Activated'), 60))
+        $this->_columns->add(new Kwf_Grid_Column('activated', trlKwf('Activated'), 60))
             ->setRenderer('boolean')
             ->setShowIn(Kwf_Grid_Column::SHOW_IN_ALL ^ Kwf_Grid_Column::SHOW_IN_XLS);
 

--- a/Kwf/User/EditModel.php
+++ b/Kwf/User/EditModel.php
@@ -39,6 +39,10 @@ class Kwf_User_EditModel extends Kwf_Model_Proxy
     {
         parent::_init();
         $this->_exprs['format'] = new Kwf_Model_Select_Expr_String('html');
+        $this->_exprs['activated'] = new Kwf_Model_Select_Expr_And(array(
+            new Kwf_Model_Select_Expr_NotEquals('password', ''),
+            new Kwf_Model_Select_Expr_Not(new Kwf_Model_Select_Expr_IsNull('password'))
+        ));
     }
 
     // wenn createRow benötigt wird weil man ein anderes userModel (db?) hat,


### PR DESCRIPTION
Since data from the grid-controller is sent to the frontend over an API,
password hashes will be exposed in the browser by adding the password column
to a controller. This poses a security risk and should therefore be avoided.