### PR TITLE
Improve whitespace-control in text-component

### DIFF
--- a/Kwc/Basic/Text/Component.twig
+++ b/Kwc/Basic/Text/Component.twig
@@ -1,9 +1,9 @@
 <div class="{{ rootElementClass }}">
     {% for part in contentParts  %}
-        {% if part is iterable %}
-            {{ renderer.component(part.component) }}
+        {%- if part is iterable %}
+            {{- renderer.component(part.component) -}}
         {% else %}
-            {{ part|mailEncodeText|raw }}
-        {% endif %}
-    {% endfor %}
+            {{- part|mailEncodeText|raw -}}
+        {% endif -%}
+    {% endfor -%}
 </div>


### PR DESCRIPTION
Problem was that whitespaces were introduced between content parts, sometimes resulting
in visible whitespaces as well.

See https://symfony.com/blog/better-white-space-control-in-twig-templates