### PR TITLE
Add getOwnUrl, not overwritten by FirstChildPage

### DIFF
--- a/Kwf/Component/Data.php
+++ b/Kwf/Component/Data.php
@@ -238,7 +238,7 @@ class Kwf_Component_Data
             if (!$this->isPage) {
                 $page = $this->getPage();
                 if (!$page) return '';
-                return $page->url;
+                return $page->ownUrl;
             }
             return $this->_getPseudoPageUrl();
         } else if ($var == 'rel') {

--- a/Kwf/Component/Data.php
+++ b/Kwf/Component/Data.php
@@ -234,6 +234,13 @@ class Kwf_Component_Data
                 return $page->url;
             }
             return $this->_getPseudoPageUrl();
+        } else if ($var == 'ownUrl') {
+            if (!$this->isPage) {
+                $page = $this->getPage();
+                if (!$page) return '';
+                return $page->url;
+            }
+            return $this->_getPseudoPageUrl();
         } else if ($var == 'rel') {
             /*
             $childs = $this->getPage()->getRecursiveChildComponents(array(


### PR DESCRIPTION
To get the real url of a page and not the overwritten one from FirstChildPage