### PR TITLE
Remove memory-limits from fulltext-rebuild

### DIFF
--- a/Kwf/Controller/Action/Cli/Web/ComponentPagesMetaController.php
+++ b/Kwf/Controller/Action/Cli/Web/ComponentPagesMetaController.php
@@ -5,7 +5,6 @@ class Kwf_Controller_Action_Cli_Web_ComponentPagesMetaController extends Kwf_Con
     public function rebuildWorkerAction()
     {
         set_time_limit(0);
-        Kwf_Util_MemoryLimit::set(512);
 
         $queueFile = 'temp/pagemetaRebuildQueue';
         $statsFile = 'temp/pagemetaRebuildStats';
@@ -97,8 +96,6 @@ class Kwf_Controller_Action_Cli_Web_ComponentPagesMetaController extends Kwf_Con
 
     public function rebuildAction()
     {
-        Kwf_Util_MemoryLimit::set(512);
-
         $m = Kwf_Component_PagesMetaModel::getInstance();
         $s = $m->select();
         $m->updateRows(array('rebuilt'=>0), $s);
@@ -157,7 +154,6 @@ class Kwf_Controller_Action_Cli_Web_ComponentPagesMetaController extends Kwf_Con
 
     public function updateChangedJobAction()
     {
-        Kwf_Util_MemoryLimit::set(512);
         $start = microtime(true);
         $m = Kwf_Component_PagesMetaModel::getInstance();
         $s = $m->select();

--- a/Kwf/Controller/Action/Cli/Web/FulltextController.php
+++ b/Kwf/Controller/Action/Cli/Web/FulltextController.php
@@ -8,7 +8,6 @@ class Kwf_Controller_Action_Cli_Web_FulltextController extends Kwf_Controller_Ac
 
     public function optimizeAction()
     {
-        Kwf_Util_MemoryLimit::set(512);
         if ($this->_getParam('debug')) echo "\noptimize index...\n";
         Kwf_Util_Fulltext_Backend_Abstract::getInstance()->optimize($this->_getParam('debug'));
         if ($this->_getParam('debug')) echo "done.\n";
@@ -171,8 +170,6 @@ class Kwf_Controller_Action_Cli_Web_FulltextController extends Kwf_Controller_Ac
 
     public function checkContentsSubrootAction()
     {
-        Kwf_Util_MemoryLimit::set(256);
-
         $subroot = Kwf_Component_Data_Root::getInstance()->getComponentById($this->_getParam('subroot'));
         if (!$subroot) $subroot = Kwf_Component_Data_Root::getInstance();
         $i = 0;


### PR DESCRIPTION
This caused issues when indexing large amounts of data.
If a memory-limit is really necessary for some reason, this could be done manually in bootstrap.php.