### PR TITLE
Fix preview XSS

### DIFF
--- a/Kwf/Controller/Action/Component/PreviewController.php
+++ b/Kwf/Controller/Action/Component/PreviewController.php
@@ -7,10 +7,17 @@ class Kwf_Controller_Action_Component_PreviewController extends Kwf_Controller_A
             'responsive' => Kwf_Config::getValue('kwc.responsive')
         );
         $this->view->xtype = 'kwf.component.preview';
-        $this->view->initialUrl = null;
+        $url = null;
         if (preg_match('#^https?://#', $this->_getParam('url'))) {
-            $this->view->initialUrl = $this->_getParam('url');
+            $url = $this->_getParam('url');
         }
+        $url = filter_var($url, FILTER_VALIDATE_URL);
+        if ($url) {
+            $parsedUrl = parse_url($url);
+            $data = Kwf_Component_Data_Root::getInstance()->getPageByUrl($parsedUrl['scheme'] . '://' . $parsedUrl['host'] . '/', '');
+            if (!$data) $url = null;
+        }
+        $this->view->initialUrl = $url;
 
         if (!$this->view->initialUrl) {
             $https = Kwf_Util_Https::domainSupportsHttps($_SERVER['HTTP_HOST']);


### PR DESCRIPTION
- Validate given url
- Allow only hosts for the current web

The value of the "url"-parameter is used as src in an iframe-tag. Without validation it is possible to format the url like `http://0wn.at:8443/"onload="alert(document.cookie)` which causes to close the src-attribute and creating an onload attribute.