### PR TITLE
Fulltext-Search find subroot with ignoreVisible

### DIFF
--- a/Kwf/Controller/Action/Cli/Web/FulltextController.php
+++ b/Kwf/Controller/Action/Cli/Web/FulltextController.php
@@ -173,7 +173,7 @@ class Kwf_Controller_Action_Cli_Web_FulltextController extends Kwf_Controller_Ac
     {
         Kwf_Util_MemoryLimit::set(256);
 
-        $subroot = Kwf_Component_Data_Root::getInstance()->getComponentById($this->_getParam('subroot'));
+        $subroot = Kwf_Component_Data_Root::getInstance()->getComponentById($this->_getParam('subroot'), array('ignoreVisible'=>true));
         if (!$subroot) $subroot = Kwf_Component_Data_Root::getInstance();
         $i = 0;
 


### PR DESCRIPTION
because if subroot is not found root is used which results in error