### PR TITLE
fix: escape query string for solr search

### DIFF
--- a/Kwf/Util/Fulltext/Backend/Solr.php
+++ b/Kwf/Util/Fulltext/Backend/Solr.php
@@ -132,13 +132,16 @@ class Kwf_Util_Fulltext_Backend_Solr extends Kwf_Util_Fulltext_Backend_Abstract
     public function search(Kwf_Component_Data $subroot, $query)
     {
         $ret = array();
-        foreach ($this->_getSolrService($subroot)->search($query)->response->docs as $doc) {
+
+        $service = $this->_getSolrService($subroot);
+        foreach ($service->search($service->escape($query))->response->docs as $doc) {
             $ret[] = array(
                 'componentId' => $doc->componentId,
                 'title' => $doc->title,
                 'content' => $doc->content,
             );
         }
+
         return $ret;
     }
 
@@ -151,7 +154,7 @@ class Kwf_Util_Fulltext_Backend_Solr extends Kwf_Util_Fulltext_Backend_Abstract
             $service->setSearchRequestHandler($params['type']);
             unset($params['type']);
         }
-        $res = $service->search($queryString, $offset, $limit, $params);
+        $res = $service->search($service->escape($queryString), $offset, $limit, $params);
         foreach ($res->response->docs as $doc) {
             $data = Kwf_Component_Data_Root::getInstance()->getComponentById($doc->componentId);
             if ($data) {


### PR DESCRIPTION
try to prevent Log4J CVE-2021-44228