### PR TITLE
Clear media cache when upload_id changes

### DIFF
--- a/Kwc/Basic/Svg/Component.php
+++ b/Kwc/Basic/Svg/Component.php
@@ -1,5 +1,5 @@
 <?php
-class Kwc_Basic_Svg_Component extends Kwc_Abstract
+class Kwc_Basic_Svg_Component extends Kwc_Abstract_Composite_Component
     implements Kwf_Media_Output_Interface
 {
     public static function getSettings($param = null)

--- a/Kwc/Basic/Svg/Events.php
+++ b/Kwc/Basic/Svg/Events.php
@@ -1,0 +1,13 @@
+<?php
+class Kwc_Basic_Svg_Events extends Kwc_Abstract_Composite_Events
+{
+    protected function _onOwnRowUpdateNotVisible(Kwf_Component_Data $c, Kwf_Events_Event_Row_Abstract $event)
+    {
+        parent::_onOwnRowUpdateNotVisible($c, $event);
+        if ($event->isDirty('kwf_upload_id')) {
+            $this->fireEvent(new Kwf_Events_Event_Media_Changed(
+                $this->_class, $c
+            ));
+        }
+    }
+}


### PR DESCRIPTION
Fixes an issue, where the old svg would be rendered after uploading a new one.