### PR TITLE
bugfix lightbox title

### DIFF
--- a/Kwf/Component/Abstract/ContentSender/Lightbox.php
+++ b/Kwf/Component/Abstract/ContentSender/Lightbox.php
@@ -69,6 +69,7 @@ class Kwf_Component_Abstract_ContentSender_Lightbox extends Kwf_Component_Abstra
             $parentContentSender = Kwc_Abstract::getSetting($parent->componentClass, 'contentSender');
             $parentContentSender = new $parentContentSender($parent);
             $parentContent = $parentContentSender->_render($includeMaster, $hasDynamicParts);
+            $title = preg_match('/<title[^>]*>(.*?)<\/title>/ims', $parentContent, $match) ? $match[1] : null;
 
             //remove main content to avoid duplicate content for search engines
             //content will be loaded using ajax
@@ -103,7 +104,7 @@ class Kwf_Component_Abstract_ContentSender_Lightbox extends Kwf_Component_Abstra
             if (isset($options['adaptHeight']) && $options['adaptHeight']) $class .= " adaptHeight";
             $options = Kwf_Util_HtmlSpecialChars::filter(json_encode($options));
             $lightboxContent =
-                "<div class=\"$class ".$kwfUniquePrefix."kwfLightboxOpen\">\n".
+                "<div class=\"$class ".$kwfUniquePrefix."kwfLightboxOpen\" data-parent-title=\"$title\">\n".
                 "    <div class=\"".$kwfUniquePrefix."kwfLightboxScrollOuter\">\n".
                 "        <div class=\"".$kwfUniquePrefix."kwfLightboxScroll\">\n".
                 "            <div class=\"".$kwfUniquePrefix."kwfLightboxBetween\">\n".

--- a/Kwf_js/EyeCandy/Lightbox/Lightbox.js
+++ b/Kwf_js/EyeCandy/Lightbox/Lightbox.js
@@ -277,8 +277,8 @@ Lightbox.prototype = {
         }).done(function(response) {
 
             injectAssets(response.assets, (function() {
-                this.closeTitle = document.title;
                 this.title = response.title ? response.title : document.title;
+                document.title = this.title; //set page-title from lightbox
                 dataLayer.push({
                     event: 'pageview',
                     pagePath: this.href,
@@ -438,6 +438,7 @@ Lightbox.prototype = {
     closeAndPushState: function() {
         if (this._isClosing) return; //prevent double-click on close button
         this._isClosing = true;
+
         if (historyState.entries > 0) {
             onlyCloseOnPopstate = true; //required to avoid flicker on closing, see popstate handler
             var previousEntries = historyState.entries;
@@ -466,11 +467,11 @@ Lightbox.prototype = {
             //location.replace(this.closeHref);
             this.close();
         }
-        document.title = this.closeTitle;
+        document.title = this.lightboxEl.attr("data-parent-title"); //set page-title back from lightbox to parent-page
         dataLayer.push({
             event: 'pageview',
             pagePath: location.pathname.substr(0, location.pathname.lastIndexOf('/')),
-            pageTitle: this.closeTitle
+            pageTitle: document.title
         });
     },
     initialize: function()


### PR DESCRIPTION
- when lightbox was opend on reload and then be closed the page title was undefined
- when lightbox was opend on click the page title does not changed to lightbox page title