### PR TITLE
Prevent exception when rendering svg that does not exist in uploads

### DIFF
--- a/Kwc/Basic/Svg/Component.php
+++ b/Kwc/Basic/Svg/Component.php
@@ -22,7 +22,10 @@ class Kwc_Basic_Svg_Component extends Kwc_Abstract
 
         if ($uploadRow) {
             if ($ret['outputType'] === 'source') {
-                $ret['fileSource'] = file_get_contents($uploadRow->getFileSource());
+                $fileSource = $uploadRow->getFileSource();
+                if (file_exists($fileSource)) {
+                    $ret['fileSource'] = file_get_contents($fileSource);
+                }
             } else if ($ret['outputType'] === 'url') {
                 $filename = $uploadRow->filename . '.' . $uploadRow->extension;
                 $url = Kwf_Media::getUrl($this->getData()->componentClass, $this->getData()->componentId, 'default', $filename);

--- a/Kwc/Basic/Svg/Component.twig
+++ b/Kwc/Basic/Svg/Component.twig
@@ -1,5 +1,5 @@
 <div class="{{ rootElementClass }}">
-    {% if outputType == 'source' %}
+    {% if outputType == 'source' and fileSource %}
         {{ fileSource|raw }}
     {% elseif outputType == 'url' %}
         <img src="{{ fileUrl }}" />


### PR DESCRIPTION
This allows for local development without the need for the production uploads.