### PR TITLE
add fix_list_elements to tinymceEditor settings,

### DIFF
--- a/Kwf_js/Form/HtmlEditor.js
+++ b/Kwf_js/Form/HtmlEditor.js
@@ -100,6 +100,7 @@ Kwf.Form.HtmlEditor = Ext2.extend(Ext2.form.HtmlEditor, {
         });
 
         var mceSettings = {
+            fix_list_elements: true, // indenting bullet lists causes invalid ul/li sequence, with this setting the lists get repaired
             forced_root_block: 'p',
             browser_spellcheck: true
         };


### PR DESCRIPTION
indenting bullet lists causes invalid ul/li sequence, with this setting the lists get repaired

see: https://www.tiny.cloud/docs-3x/reference/Configuration3x/Configuration3x@fix_list_elements/