### PR TITLE
Allow overriding 'getParent()' in lightbox content-sender

### DIFF
--- a/Kwf/Component/Abstract/ContentSender/Lightbox.php
+++ b/Kwf/Component/Abstract/ContentSender/Lightbox.php
@@ -14,7 +14,7 @@ class Kwf_Component_Abstract_ContentSender_Lightbox extends Kwf_Component_Abstra
         return $ret;
     }
 
-    private function _getParent()
+    protected function _getParent()
     {
         $previous = null;
         $parent = $this->_data->parent;


### PR DESCRIPTION
This allows customizing which page will be rendered behind the lightbox.