### PR TITLE
use closeTitle like before fix 1148 when no data-parent-title

### DIFF
--- a/Kwf_js/EyeCandy/Lightbox/Lightbox.js
+++ b/Kwf_js/EyeCandy/Lightbox/Lightbox.js
@@ -277,6 +277,7 @@ Lightbox.prototype = {
         }).done(function(response) {
 
             injectAssets(response.assets, (function() {
+                this.closeTitle = document.title;
                 this.title = response.title ? response.title : document.title;
                 document.title = this.title; //set page-title from lightbox
                 dataLayer.push({
@@ -467,7 +468,11 @@ Lightbox.prototype = {
             //location.replace(this.closeHref);
             this.close();
         }
-        document.title = this.lightboxEl.attr("data-parent-title"); //set page-title back from lightbox to parent-page
+        if (this.lightboxEl.attr("data-parent-title")) {
+            document.title = this.lightboxEl.attr("data-parent-title"); //set page-title back from lightbox to parent-page
+        } else {
+            document.title = this.closeTitle;
+        }
         dataLayer.push({
             event: 'pageview',
             pagePath: location.pathname.substr(0, location.pathname.lastIndexOf('/')),


### PR DESCRIPTION
- when open lightbox the title changes to lightbox title but is undefined when closing lightbox
- 1148 fixed bug when lightbox url is loaded directly and got no title when closing
- now both is supportet

