### PR TITLE
Don't skip empty text-element in block-element

### DIFF
--- a/Kwc/Basic/Text/ApiContentHtmlParser.php
+++ b/Kwc/Basic/Text/ApiContentHtmlParser.php
@@ -20,8 +20,6 @@ class Kwc_Basic_Text_ApiContentHtmlParser
                 if (isset($current->children)) {
                     $filteredChildren = array();
                     foreach ($current->children as $key => $child) {
-                        // empty text-elemente in block-element not allowed
-                        if ($child->element == 'text' && trim($child->text) == '') continue;
                          // trailing spaces in last segment of block not allowed
                         if ($child->element == 'text' && $key == count($current->children)-1) $child->text = rtrim($child->text);
                         $filteredChildren[] = $child;


### PR DESCRIPTION
somehow spaces are converted into separate text-elements and then filtered out. I introduced this but I can't remember which problem it should fix so I'm "reverting" this change to fix the current bug.

e.g.
"lorem <strong>ipsum</strong> <strong>dolor</strong> <strong>sit</strong> amet" is converted to
```
{
    "element":"p",
    "children":[
        {
            "element":"text",
            "text":"lorem "
        },{
            "element":"strong",
            "children":[
                {"element":"text","text":"ipsum"}
            ]
        },{
            "element":"strong",
            "children":[
                {"element":"text","text":"dolor"}
            ]
        },{
            "element":"strong",
            "children":[
                {"element":"text","text":"sit"}
            ]
        },{
            "element":"text",
            "text":" amet"
        }
    ]
}
```
missing spaces between strong-elements