### PR TITLE
Fix fieldConfigs for NonAjax Views

### DIFF
--- a/Kwc/Form/NonAjax/Component.php
+++ b/Kwc/Form/NonAjax/Component.php
@@ -323,6 +323,19 @@ class Kwc_Form_NonAjax_Component extends Kwc_Abstract_Composite_Component
 
         $ret['submitCaption'] = $this->_getPlaceholder('submitButton');
 
+        $fieldConfig = array();
+        $iterator = new RecursiveIteratorIterator(new Kwf_Collection_Iterator_RecursiveFormFields($this->_form->fields), RecursiveIteratorIterator::SELF_FIRST);
+        foreach ($iterator as $field) {
+            if ($field->getFieldName()) {
+                $fieldConfig[$field->getFieldName()] = (object)$field->getFrontendMetaData();
+            }
+        }
+
+        $ret['config'] = array(
+            'componentId' => $this->getData()->componentId,
+            'fieldConfig' => (object)$fieldConfig,
+        );
+
         return $ret;
     }
 


### PR DESCRIPTION
Recaptcha and Cards need the fieldConfig in the FrontendForm
Issue was found in 5.4, fixed in 4.5 (first NonAjax version)