### PR TITLE
Add fallback for redirect-param

### DIFF
--- a/Kwc/User/Login/Component.php
+++ b/Kwc/User/Login/Component.php
@@ -31,7 +31,7 @@ class Kwc_User_Login_Component extends Kwc_Abstract_Composite_Component
             if (!isset($authMethods[$postData['redirectAuth']])) throw new Kwf_Exception_NotFound();
             $auth = $authMethods[$postData['redirectAuth']];
             if (!$auth instanceof Kwf_User_Auth_Interface_Redirect) throw new Kwf_Exception_NotFound();
-            $redirectBackUrl = $_GET['redirect'];
+            $redirectBackUrl = isset($_GET['redirect']) && $_GET['redirect'] != "" ? $_GET['redirect'] : '/';
 
             $f = new Kwf_Filter_StrongRandom();
             $state = 'login.'.$postData['redirectAuth'].'.'.$f->filter(null).'.'.urlencode(str_replace('.', 'kwfdot', $redirectBackUrl));


### PR DESCRIPTION
An infinite loop occurs if the redirect-param is not set. The user is being redirected to the login-page where the authorization request is sent multiple times with the same access-token, which does not work because the access-token has already been invalidated. Redirecting to the home-page works because at this point the user is already loggend in.