### PR TITLE
Always render the `alt` attribute on images

### DIFF
--- a/commonjs/responsive-img.js
+++ b/commonjs/responsive-img.js
@@ -91,9 +91,7 @@ function initResponsiveImgEl(el) {
             img.attr('title', title[1]);
         }
         var alt = noscript.match(/alt="([^"]+)"/);
-        if (alt) {
-            img.attr('alt', alt[1]);
-        }
+        img.attr('alt', alt ? alt[1] : "");
     }
     el.trigger('changesrc', sizePath);
 };


### PR DESCRIPTION
The attribute is always required for accessibility, decorative images require an empty `alt` attribute.

See https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images